### PR TITLE
feat(metamodel): align with output from concerto codegen

### DIFF
--- a/ConcertoJsonConverter/concerto.cs
+++ b/ConcertoJsonConverter/concerto.cs
@@ -1,46 +1,46 @@
 using System;
 using System.Text.Json.Serialization;
-using NewtonsoftJson = Newtonsoft.Json;
 using Concerto.Serialization;
+using NewtonsoftJson = Newtonsoft.Json;
 using NewtonsoftConcerto = Concerto.Serialization.Newtonsoft;
 namespace Concerto.Models.concerto {
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public virtual string _class { get;} = "concerto.Concept";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public virtual string _class { get;} = "concerto.Concept";
    }
    public abstract class Asset : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.Asset";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.Asset";
       [JsonPropertyName("$identifier")]
-        [NewtonsoftJson.JsonProperty("$identifier")]
-        public string _identifier { get; set; }
+		[NewtonsoftJson.JsonProperty("$identifier")]
+		public string _identifier { get; set; }
    }
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Participant : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.Participant";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.Participant";
       [JsonPropertyName("$identifier")]
-        [NewtonsoftJson.JsonProperty("$identifier")]
-        public string _identifier { get; set; }
+		[NewtonsoftJson.JsonProperty("$identifier")]
+		public string _identifier { get; set; }
    }
    public abstract class Transaction : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.Transaction";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.Transaction";
       [JsonPropertyName("$timestamp")]
-        [NewtonsoftJson.JsonProperty("$timestamp")]
-        public DateTime _timestamp { get; set; }
+		[NewtonsoftJson.JsonProperty("$timestamp")]
+		public DateTime _timestamp { get; set; }
    }
    public abstract class Event : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.Event";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.Event";
       [JsonPropertyName("$timestamp")]
-        [NewtonsoftJson.JsonProperty("$timestamp")]
-        public DateTime _timestamp { get; set; }
+		[NewtonsoftJson.JsonProperty("$timestamp")]
+		public DateTime _timestamp { get; set; }
    }
 }

--- a/ConcertoJsonConverter/concerto.metamodel.cs
+++ b/ConcertoJsonConverter/concerto.metamodel.cs
@@ -1,71 +1,71 @@
 using System;
 using System.Text.Json.Serialization;
-using NewtonsoftJson = Newtonsoft.Json;
 using Concerto.Serialization;
+using NewtonsoftJson = Newtonsoft.Json;
 using NewtonsoftConcerto = Concerto.Serialization.Newtonsoft;
 namespace Concerto.Models.concerto.metamodel {
    using Concerto.Models.concerto;
    public class Position : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Position";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Position";
       public int line { get; set; }
       public int column { get; set; }
       public int offset { get; set; }
    }
    public class Range : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Range";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Range";
       public Position start { get; set; }
       public Position end { get; set; }
       public string source { get; set; }
    }
    public class TypeIdentifier : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.TypeIdentifier";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.TypeIdentifier";
       public string name { get; set; }
       [JsonPropertyName("namespace")]
-        [NewtonsoftJson.JsonProperty("namespace")]
-        public string _namespace { get; set; }
+		[NewtonsoftJson.JsonProperty("namespace")]
+		public string _namespace { get; set; }
    }
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class DecoratorLiteral : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DecoratorLiteral";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DecoratorLiteral";
       public Range location { get; set; }
    }
    public class DecoratorString : DecoratorLiteral {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DecoratorString";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DecoratorString";
       public string value { get; set; }
    }
    public class DecoratorNumber : DecoratorLiteral {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DecoratorNumber";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DecoratorNumber";
       public float value { get; set; }
    }
    public class DecoratorBoolean : DecoratorLiteral {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DecoratorBoolean";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DecoratorBoolean";
       public bool value { get; set; }
    }
    public class DecoratorTypeReference : DecoratorLiteral {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DecoratorTypeReference";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DecoratorTypeReference";
       public TypeIdentifier type { get; set; }
       public bool isArray { get; set; }
    }
    public class Decorator : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Decorator";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Decorator";
       public string name { get; set; }
       public DecoratorLiteral[] arguments { get; set; }
       public Range location { get; set; }
@@ -73,34 +73,34 @@ namespace Concerto.Models.concerto.metamodel {
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public class Identified : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Identified";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Identified";
    }
    public class IdentifiedBy : Identified {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.IdentifiedBy";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.IdentifiedBy";
       public string name { get; set; }
    }
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Declaration : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Declaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Declaration";
       public string name { get; set; }
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
    public class EnumDeclaration : Declaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.EnumDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.EnumDeclaration";
       public EnumProperty[] properties { get; set; }
    }
    public class EnumProperty : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.EnumProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.EnumProperty";
       public string name { get; set; }
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
@@ -108,8 +108,8 @@ namespace Concerto.Models.concerto.metamodel {
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public class ConceptDeclaration : Declaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.ConceptDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.ConceptDeclaration";
       public bool isAbstract { get; set; }
       public Identified identified { get; set; }
       public TypeIdentifier superType { get; set; }
@@ -117,29 +117,29 @@ namespace Concerto.Models.concerto.metamodel {
    }
    public class AssetDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.AssetDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.AssetDeclaration";
    }
    public class ParticipantDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.ParticipantDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.ParticipantDeclaration";
    }
    public class TransactionDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.TransactionDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.TransactionDeclaration";
    }
    public class EventDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.EventDeclaration";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.EventDeclaration";
    }
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Property : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Property";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Property";
       public string name { get; set; }
       public bool isArray { get; set; }
       public bool isOptional { get; set; }
@@ -148,112 +148,112 @@ namespace Concerto.Models.concerto.metamodel {
    }
    public class RelationshipProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.RelationshipProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.RelationshipProperty";
       public TypeIdentifier type { get; set; }
    }
    public class ObjectProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.ObjectProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.ObjectProperty";
       public string defaultValue { get; set; }
       public TypeIdentifier type { get; set; }
    }
    public class BooleanProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.BooleanProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.BooleanProperty";
       public bool defaultValue { get; set; }
    }
    public class DateTimeProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DateTimeProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DateTimeProperty";
    }
    public class StringProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.StringProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.StringProperty";
       public string defaultValue { get; set; }
       public StringRegexValidator validator { get; set; }
    }
    public class StringRegexValidator : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.StringRegexValidator";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.StringRegexValidator";
       public string pattern { get; set; }
       public string flags { get; set; }
    }
    public class DoubleProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DoubleProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DoubleProperty";
       public float defaultValue { get; set; }
       public DoubleDomainValidator validator { get; set; }
    }
    public class DoubleDomainValidator : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.DoubleDomainValidator";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.DoubleDomainValidator";
       public float lower { get; set; }
       public float upper { get; set; }
    }
    public class IntegerProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.IntegerProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.IntegerProperty";
       public int defaultValue { get; set; }
       public IntegerDomainValidator validator { get; set; }
    }
    public class IntegerDomainValidator : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.IntegerDomainValidator";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.IntegerDomainValidator";
       public int lower { get; set; }
       public int upper { get; set; }
    }
    public class LongProperty : Property {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.LongProperty";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.LongProperty";
       public long defaultValue { get; set; }
       public LongDomainValidator validator { get; set; }
    }
    public class LongDomainValidator : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.LongDomainValidator";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.LongDomainValidator";
       public long lower { get; set; }
       public long upper { get; set; }
    }
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Import : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Import";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Import";
       [JsonPropertyName("namespace")]
-        [NewtonsoftJson.JsonProperty("namespace")]
-        public string _namespace { get; set; }
+		[NewtonsoftJson.JsonProperty("namespace")]
+		public string _namespace { get; set; }
       public string uri { get; set; }
    }
    public class ImportAll : Import {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.ImportAll";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.ImportAll";
    }
    public class ImportType : Import {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.ImportType";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.ImportType";
       public string name { get; set; }
    }
    public class Model : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Model";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Model";
       [JsonPropertyName("namespace")]
-        [NewtonsoftJson.JsonProperty("namespace")]
-        public string _namespace { get; set; }
+		[NewtonsoftJson.JsonProperty("namespace")]
+		public string _namespace { get; set; }
       public string sourceUri { get; set; }
       public string concertoVersion { get; set; }
       public Import[] imports { get; set; }
@@ -261,8 +261,8 @@ namespace Concerto.Models.concerto.metamodel {
    }
    public class Models : Concept {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "concerto.metamodel.Models";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "concerto.metamodel.Models";
       public Model[] models { get; set; }
    }
 }

--- a/ConcertoJsonConverter/org.test.cs
+++ b/ConcertoJsonConverter/org.test.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Text.Json.Serialization;
-using NewtonsoftJson = Newtonsoft.Json;
 using Concerto.Serialization;
+using NewtonsoftJson = Newtonsoft.Json;
 using NewtonsoftConcerto = Concerto.Serialization.Newtonsoft;
 namespace Concerto.Models.org.test {
    using Concerto.Models.concerto;
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public abstract class Person : Participant {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "org.test.Person";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "org.test.Person";
       public string email { get; set; }
       public string firstName { get; set; }
       public string lastName { get; set; }
@@ -24,16 +24,16 @@ namespace Concerto.Models.org.test {
    [NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]
    public class Employee : Person {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "org.test.Employee";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "org.test.Employee";
       public Department? department { get; set; }
       public Employee manager { get; set; }
       public string employeeId { get; set; }
    }
    public class Manager : Employee {
       [JsonPropertyName("$class")]
-        [NewtonsoftJson.JsonProperty("$class")]
-        public override string _class { get;} = "org.test.Manager";
+		[NewtonsoftJson.JsonProperty("$class")]
+		public override string _class { get;} = "org.test.Manager";
       public float budget { get; set; }
    }
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ using Concerto.Models.org.test;
 
 > This repository uses statically built versions of the internal `Concerto.Models.concerto` and `Concerto.Models.concerto.metamodel` namespaces. In the future this should be build dynamically using the Concerto CLI. There is an [open branch with the changes needed to `concerto-tools` package](https://github.com/mttrbrts/composer-concerto/blob/mr-csharp-newtonsoft/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js). You can build the C# classes from the Concerto source files (`.cto`) will the following command:
 >
-> `concerto compile --model ./models/concerto.metamodel.cto --model ./models/employee.cto --target csharp --output ./`
+> `concerto compile --model ./models/concerto.metamodel.cto --model ./models/employee.cto --target csharp --output ./ --useSystemTextJson --useNewtonsoftJson`
 
 ## Running Tests
 


### PR DESCRIPTION
A minor change to align the base concerto types with the output of the latest C# codegen from `concerto-tools`.

i.e. The changed files were created with the following command:
```
concerto compile --model ./models/concerto.metamodel.cto --model ./models/employee.cto --target csharp --output ./ --useSystemTextJson --useNewtonsoftJson`
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
