### PR TITLE
feat(*): add empty accordproject solution and publishing to nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,13 @@
-name: Build
+name: Publish
 
 on:
-  push:
-  pull_request:
-    branches:
-      - main
+  release:
+    types:
+      - published
 
 jobs:
-  build:
-    name: Build and test
+  publish:
+    name: Build, test and publish
 
     strategy:
       matrix:
@@ -40,5 +39,10 @@ jobs:
         run: |
           dotnet test AccordProject.Concerto.sln --no-restore --verbosity normal
           dotnet test ConcertoJsonConverter.sln --no-restore --verbosity normal
-
+      - name: Pack
+        run: |
+          dotnet pack AccordProject.Concerto.sln --configuration Release --no-restore /p:Version=${{ github.event.release.tag_name }}
+      - name: Nuget Push
+        run: |
+          dotnet nuget push AccordProject.Concerto/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_KEY }}
 

--- a/AccordProject.Concerto.sln
+++ b/AccordProject.Concerto.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccordProject.Concerto", "AccordProject.Concerto\AccordProject.Concerto.csproj", "{FA860B12-15D2-440A-96A4-6D68AD72E159}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/AccordProject.Concerto/AccordProject.Concerto.csproj
+++ b/AccordProject.Concerto/AccordProject.Concerto.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AccordProject.Concerto/Concerto.cs
+++ b/AccordProject.Concerto/Concerto.cs
@@ -1,0 +1,1 @@
+﻿namespace AccordProject.Concerto;


### PR DESCRIPTION
Add an empty AccordProject.Concerto package, and publish it to Nuget when a release is published.

There is an existing Concerto package on Nuget and so we are going to move everything under the AccordProject.Concerto package.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>