### PR TITLE
feat(*): concerto type attributes

### DIFF
--- a/AccordProject.Concerto/ConcertoAttributes.cs
+++ b/AccordProject.Concerto/ConcertoAttributes.cs
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace AccordProject.Concerto;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class Type : Attribute {
+    public string Namespace;
+    public string? Version;
+    public string Name;
+}

--- a/AccordProject.Concerto/ConcertoMetamodelTypes.cs
+++ b/AccordProject.Concerto/ConcertoMetamodelTypes.cs
@@ -17,6 +17,7 @@ using System.Text.Json.Serialization;
 
 namespace AccordProject.Concerto.Metamodel {
    using AccordProject.Concerto;
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Position")]
    public class Position : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Position";
@@ -24,6 +25,7 @@ namespace AccordProject.Concerto.Metamodel {
       public int column { get; set; }
       public int offset { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Range")]
    public class Range : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Range";
@@ -31,6 +33,7 @@ namespace AccordProject.Concerto.Metamodel {
       public Position end { get; set; }
       public string source { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TypeIdentifier")]
    public class TypeIdentifier : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.TypeIdentifier";
@@ -38,32 +41,38 @@ namespace AccordProject.Concerto.Metamodel {
       [JsonPropertyName("namespace")]
 		public string _namespace { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorLiteral")]
    public abstract class DecoratorLiteral : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorLiteral";
       public Range location { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorString")]
    public class DecoratorString : DecoratorLiteral {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorString";
       public string value { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorNumber")]
    public class DecoratorNumber : DecoratorLiteral {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorNumber";
       public float value { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorBoolean")]
    public class DecoratorBoolean : DecoratorLiteral {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorBoolean";
       public bool value { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorTypeReference")]
    public class DecoratorTypeReference : DecoratorLiteral {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorTypeReference";
       public TypeIdentifier type { get; set; }
       public bool isArray { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Decorator")]
    public class Decorator : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Decorator";
@@ -71,15 +80,18 @@ namespace AccordProject.Concerto.Metamodel {
       public DecoratorLiteral[] arguments { get; set; }
       public Range location { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Identified")]
    public class Identified : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Identified";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IdentifiedBy")]
    public class IdentifiedBy : Identified {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IdentifiedBy";
       public string name { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Declaration")]
    public abstract class Declaration : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Declaration";
@@ -87,11 +99,13 @@ namespace AccordProject.Concerto.Metamodel {
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumDeclaration")]
    public class EnumDeclaration : Declaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumDeclaration";
       public EnumProperty[] properties { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumProperty")]
    public class EnumProperty : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumProperty";
@@ -99,6 +113,7 @@ namespace AccordProject.Concerto.Metamodel {
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ConceptDeclaration")]
    public class ConceptDeclaration : Declaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ConceptDeclaration";
@@ -107,22 +122,27 @@ namespace AccordProject.Concerto.Metamodel {
       public TypeIdentifier superType { get; set; }
       public Property[] properties { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "AssetDeclaration")]
    public class AssetDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.AssetDeclaration";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ParticipantDeclaration")]
    public class ParticipantDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ParticipantDeclaration";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TransactionDeclaration")]
    public class TransactionDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.TransactionDeclaration";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EventDeclaration")]
    public class EventDeclaration : ConceptDeclaration {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EventDeclaration";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Property")]
    public abstract class Property : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Property";
@@ -132,74 +152,87 @@ namespace AccordProject.Concerto.Metamodel {
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "RelationshipProperty")]
    public class RelationshipProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.RelationshipProperty";
       public TypeIdentifier type { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ObjectProperty")]
    public class ObjectProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ObjectProperty";
       public string defaultValue { get; set; }
       public TypeIdentifier type { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "BooleanProperty")]
    public class BooleanProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.BooleanProperty";
       public bool defaultValue { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DateTimeProperty")]
    public class DateTimeProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DateTimeProperty";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringProperty")]
    public class StringProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.StringProperty";
       public string defaultValue { get; set; }
       public StringRegexValidator validator { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringRegexValidator")]
    public class StringRegexValidator : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.StringRegexValidator";
       public string pattern { get; set; }
       public string flags { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleProperty")]
    public class DoubleProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleProperty";
       public float defaultValue { get; set; }
       public DoubleDomainValidator validator { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleDomainValidator")]
    public class DoubleDomainValidator : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleDomainValidator";
       public float lower { get; set; }
       public float upper { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerProperty")]
    public class IntegerProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerProperty";
       public int defaultValue { get; set; }
       public IntegerDomainValidator validator { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerDomainValidator")]
    public class IntegerDomainValidator : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerDomainValidator";
       public int lower { get; set; }
       public int upper { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongProperty")]
    public class LongProperty : Property {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.LongProperty";
       public long defaultValue { get; set; }
       public LongDomainValidator validator { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongDomainValidator")]
    public class LongDomainValidator : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.LongDomainValidator";
       public long lower { get; set; }
       public long upper { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Import")]
    public abstract class Import : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Import";
@@ -207,20 +240,24 @@ namespace AccordProject.Concerto.Metamodel {
 		public string _namespace { get; set; }
       public string uri { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportAll")]
    public class ImportAll : Import {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportAll";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportType")]
    public class ImportType : Import {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportType";
       public string name { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportTypes")]
    public class ImportTypes : Import {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportTypes";
       public string[] types { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Model")]
    public class Model : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Model";
@@ -230,7 +267,9 @@ namespace AccordProject.Concerto.Metamodel {
       public string concertoVersion { get; set; }
       public Import[] imports { get; set; }
       public Declaration[] declarations { get; set; }
+      public Decorator[] decorators { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Models")]
    public class Models : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Models";

--- a/AccordProject.Concerto/ConcertoTypes.cs
+++ b/AccordProject.Concerto/ConcertoTypes.cs
@@ -16,28 +16,33 @@ using System;
 using System.Text.Json.Serialization;
 
 namespace AccordProject.Concerto {
+   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
    public abstract class Concept {
       [JsonPropertyName("$class")]
 		public virtual string _class { get; } = "concerto@1.0.0.Concept";
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Asset")]
    public abstract class Asset : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Asset";
       [JsonPropertyName("$identifier")]
 		public string _identifier { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Participant")]
    public abstract class Participant : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Participant";
       [JsonPropertyName("$identifier")]
 		public string _identifier { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Transaction")]
    public abstract class Transaction : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Transaction";
       [JsonPropertyName("$timestamp")]
 		public DateTime _timestamp { get; set; }
    }
+   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Event")]
    public abstract class Event : Concept {
       [JsonPropertyName("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Event";


### PR DESCRIPTION
Now that Concerto allows the .NET namespace to be customized, the .NET namespace and class name cannot be relied upon to infer the underlying Concerto namespace, version and name.

This change introduces a new `Type` attribute that can be attached to classes that extend `Concept`, to provide the Concerto namespace, version and name.

We can use introspection at runtime to read this information.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>