### PR TITLE
fix(*): change type class name

### DIFF
--- a/AccordProject.Concerto/ConcertoAttributes.cs
+++ b/AccordProject.Concerto/ConcertoAttributes.cs
@@ -17,7 +17,7 @@ using System;
 namespace AccordProject.Concerto;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class Type : Attribute {
+public class TypeAttribute : Attribute {
     public string Namespace;
     public string? Version;
     public string Name;


### PR DESCRIPTION
In C#, attribute classes can have their name optionally end in `Attribute`, but the usage of the attribute does not change.

So if we have `class TypeAttribute`, we can use it as `[Type]`.

This helps disambiguate it from `System.Type`.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>