### PR TITLE
feat(*): add type dictionary and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,7 +372,7 @@ FodyWeavers.xsd
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-*.code-workspace
+# *.code-workspace
 
 # Local History for Visual Studio Code
 .history/

--- a/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
+++ b/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ExpectedObjects" Version="3.5.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AccordProject.Concerto\AccordProject.Concerto.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AccordProject.Concerto.Tests/ConcertoTypeDictionaryTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoTypeDictionaryTests.cs
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests;
+
+using System;
+using AccordProject.Concerto;
+using AccordProject.Concerto.Metamodel;
+
+public class ConcertoTypeDictionaryTests
+{
+    [Fact]
+    public void ReturnsBaseTypeFromString()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType("concerto@1.0.0.Concept");
+        Assert.Equal(type, typeof(Concept));
+    }
+
+    [Fact]
+    public void ReturnsBaseTypeFromStruct()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType(new ConcertoType() {
+            Namespace = "concerto",
+            Version = "1.0.0",
+            Name = "Concept"
+        });
+        Assert.Equal(type, typeof(Concept));
+    }
+
+    [Fact]
+    public void ReturnsMetamodelTypeFromString()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType("concerto.metamodel@1.0.0.ConceptDeclaration");
+        Assert.Equal(type, typeof(ConceptDeclaration));
+    }
+
+    [Fact]
+    public void ReturnsMetamodelTypeFromStruct()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType(new ConcertoType() {
+            Namespace = "concerto.metamodel",
+            Version = "1.0.0",
+            Name = "ConceptDeclaration"
+        });
+        Assert.Equal(type, typeof(ConceptDeclaration));
+    }
+
+    [Fact]
+    public void ReturnsNullForMissingTypeFromString()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType("nosuchmodel@1.0.0.NoSuchType");
+        Assert.Null(type);
+    }
+
+    [Fact]
+    public void ReturnsNullForMissingTypeFromStruct()
+    {
+        var dictionary = ConcertoTypeDictionary.Instance;
+        var type = dictionary.ResolveType(new ConcertoType() {
+            Namespace = "nosuchmodel",
+            Version = "1.0.0",
+            Name = "NoSuchType"
+        });
+        Assert.Null(type);
+    }
+}

--- a/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests;
+
+using System;
+using AccordProject.Concerto;
+
+public class ConcertoUtilsTests
+{
+    [Fact]
+    public void CanParseUnversionedType()
+    {
+        var expected = new ConcertoType() {
+            Namespace = "org.example",
+            Name = "Foo"
+        }.ToExpectedObject();
+        var actual = ConcertoUtils.ParseType("org.example.Foo");
+        expected.ShouldEqual(actual);
+    }
+
+    [Fact]
+    public void CanParseVersionedType()
+    {
+        var expected = new ConcertoType() {
+            Namespace = "org.example",
+            Version = "1.2.3",
+            Name = "Foo"
+        }.ToExpectedObject();
+        var actual = ConcertoUtils.ParseType("org.example@1.2.3.Foo");
+        expected.ShouldEqual(actual);
+    }
+         
+    [Fact]
+    public void CannotParseTypeWithMissingPeriod()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseType("org"));
+        Assert.Equal("Invalid fully qualified name \"org\"", ex.Message);
+    }
+         
+    [Fact]
+    public void CannotParseTypeWithEmptyNamespace()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseType(".Foo"));
+        Assert.Equal("Invalid fully qualified name \".Foo\"", ex.Message);
+    }
+         
+    [Fact]
+    public void CannotParseTypeWithEmptyName()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseType("org.example."));
+        Assert.Equal("Invalid fully qualified name \"org.example.\"", ex.Message);
+    }
+         
+    [Fact]
+    public void CannotParseTypeWithEmptyVersion()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseType("org.example@.Foo"));
+        Assert.Equal("Invalid fully qualified name \"org.example@.Foo\"", ex.Message);
+    }
+}

--- a/AccordProject.Concerto.Tests/Usings.cs
+++ b/AccordProject.Concerto.Tests/Usings.cs
@@ -12,20 +12,5 @@
  * limitations under the License.
  */
 
-namespace AccordProject.Concerto;
-
-[AttributeUsage(AttributeTargets.Class)]
-public class TypeAttribute : Attribute {
-    public string Namespace;
-    public string? Version;
-    public string Name;
-
-    public ConcertoType ToType()
-    {
-        return new ConcertoType() {
-            Namespace = Namespace,
-            Version = Version,
-            Name = Name
-        };
-    }
-}
+global using Xunit;
+global using ExpectedObjects;

--- a/AccordProject.Concerto.code-workspace
+++ b/AccordProject.Concerto.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "AccordProject.Concerto"
+		},
+		{
+			"path": "AccordProject.Concerto.Tests"
+		}
+	],
+	"settings": {}
+}

--- a/AccordProject.Concerto.sln
+++ b/AccordProject.Concerto.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccordProject.Concerto", "AccordProject.Concerto\AccordProject.Concerto.csproj", "{FA860B12-15D2-440A-96A4-6D68AD72E159}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AccordProject.Concerto.Tests", "AccordProject.Concerto.Tests\AccordProject.Concerto.Tests.csproj", "{CE1422D6-5783-4F86-9087-154FE0C2ECD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA860B12-15D2-440A-96A4-6D68AD72E159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE1422D6-5783-4F86-9087-154FE0C2ECD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE1422D6-5783-4F86-9087-154FE0C2ECD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE1422D6-5783-4F86-9087-154FE0C2ECD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE1422D6-5783-4F86-9087-154FE0C2ECD3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/AccordProject.Concerto/AccordProject.Concerto.csproj
+++ b/AccordProject.Concerto/AccordProject.Concerto.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/AccordProject.Concerto/ConcertoTypeDictionary.cs
+++ b/AccordProject.Concerto/ConcertoTypeDictionary.cs
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
+using AccordProject.Concerto;
+
+/// <summary>
+/// This singleton class provides a dictionary that maps Concerto types to .NET class types.
+/// </summary>
+public class ConcertoTypeDictionary
+{
+    private static readonly Lazy<ConcertoTypeDictionary> lazy = new Lazy<ConcertoTypeDictionary>(() => new ConcertoTypeDictionary());
+    
+    public static ConcertoTypeDictionary Instance { get { return lazy.Value; } }
+
+    private Dictionary<ConcertoType, Type> entries = new Dictionary<ConcertoType, Type>();
+
+    private ConcertoTypeDictionary()
+    {
+        var currentDomain = AppDomain.CurrentDomain;
+        // Subscribe to event that informs us of any new assemblies.
+        currentDomain.AssemblyLoad += AssemblyLoaded;
+        LoadTypesFromAppDomain(currentDomain);
+    }
+
+    ~ConcertoTypeDictionary()
+    {
+        var currentDomain = AppDomain.CurrentDomain;
+        // Unsubscribe from event that informs us of any new assemblies.
+        currentDomain.AssemblyLoad -= AssemblyLoaded;
+    }
+
+    public Type? ResolveType(string fqn)
+    {
+        var type = ConcertoUtils.ParseType(fqn);
+        return ResolveType(type);
+    }
+
+    public Type? ResolveType(ConcertoType type)
+    {
+        var exists = entries.TryGetValue(type, out Type? value);
+        if (!exists)
+        {
+            return null;
+        }
+        return value;
+    }
+
+    private void AssemblyLoaded(object? sender, AssemblyLoadEventArgs args)
+    {
+        var assembly = args.LoadedAssembly;
+        LoadTypesFromAssembly(assembly);
+    }
+
+    private void LoadTypesFromAppDomain(AppDomain appDomain)
+    {
+        var assemblies = appDomain.GetAssemblies();
+        LoadTypesFromAssemblies(assemblies);
+    }
+
+    private void LoadTypesFromAssemblies(Assembly[] assemblies)
+    {
+        foreach (var assembly in assemblies)
+        {
+            LoadTypesFromAssembly(assembly);
+        }
+    }
+
+    private void LoadTypesFromAssembly(Assembly assembly)
+    {
+        var types = assembly.GetTypes().Where(type =>
+            type.IsClass
+            && type.IsAssignableTo(typeof(Concept))
+            && type.GetCustomAttribute<TypeAttribute>() != null);
+        foreach (var type in types)
+        {
+            var attribute = type.GetCustomAttribute<TypeAttribute>();
+            var key = attribute!.ToType();
+            entries.Add(key, type);
+        }
+    }
+}   

--- a/AccordProject.Concerto/ConcertoUtils.cs
+++ b/AccordProject.Concerto/ConcertoUtils.cs
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <summary>
+/// This class represents a Concerto type, for example org.example@1.2.3.Foo.
+/// </summary>
+public struct ConcertoType
+{
+    public string Namespace { get; init; }
+    public string? Version { get; init; }
+    public string Name { get; init; }
+
+    public override string ToString()
+    {
+        if (Version != null)
+        {
+            return $"{Namespace}@{Version}.{Name}";
+        }
+        return $"{Namespace}.{Name}";
+    }
+}
+
+/// <summary>
+/// This class provides static utility methods.
+/// </summary>
+public class ConcertoUtils
+{
+    public static ConcertoType ParseType(string fqn)
+    {
+        int i = fqn.LastIndexOf(".");
+        if (i == -1)
+        {
+            throw new Exception($"Invalid fully qualified name \"{fqn}\"");
+        }
+        var namespaceAndVersion = fqn[..i];
+        var name = fqn[(i + 1)..];
+        if (name.Length == 0)
+        {
+            throw new Exception($"Invalid fully qualified name \"{fqn}\"");
+        }
+        string ns;
+        string? version = null;
+        int j = namespaceAndVersion.IndexOf("@");
+        if (j != -1)
+        {
+            ns = namespaceAndVersion[..j];
+            version = namespaceAndVersion[(j + 1)..];
+        }
+        else
+        {
+            ns = namespaceAndVersion;
+        }
+        if (ns.Length == 0 || version?.Length == 0)
+        {
+            throw new Exception($"Invalid fully qualified name \"{fqn}\"");
+        }
+        return new ConcertoType() { Namespace = ns, Version = version, Name = name };
+    }
+}


### PR DESCRIPTION
This change extracts the type dictionary functionality from the prototype code into a separate singleton class, in preparation for work on the JSON converters.

The `ConcertoTypeDictionary` singleton class loads all Concerto types from all assemblies in the current app domain when instantiated, and then loads all Concerto types from any assemblies that are loaded in the current app domain after instantiation. 

This allows us to find Concerto types from other assemblies, which will be the most common use case - users Concerto types will not be in our `AccordProject.Concerto` assembly. Searching all of the assemblies is expensive and we don't want to do it repeatedly, which is why we use a singleton, and subscribe to app domain events for new assemblies.

I've also introduced a new `AccordProject.Concerto.Tests` project for unit tests, and a new VS Code workspace file which you need to use if you want all of the C# language features to work correctly.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>