### PR TITLE
feat(*): newtonsoft converter

### DIFF
--- a/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
+++ b/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ExpectedObjects" Version="3.5.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests;
+
+using System;
+using AccordProject.Concerto;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+public class ConcertoConverterNewtonsoftDeserializeTests
+{
+    JsonSerializerSettings options = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore,
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        Converters =
+        {
+            new StringEnumConverter(),
+        }
+    };
+
+    [Fact]
+    public void SimpleObject_Succeeds()
+    {
+        string jsonString = @"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+            ""department"": ""ENGINEERING"",
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }";
+
+        var employee = JsonConvert.DeserializeObject<Employee>(jsonString, options).ToExpectedObject();
+
+        employee.ShouldEqual(new Employee()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123"
+        });
+    }
+
+    [Fact]
+    public void SimpleObject_DeserializeToSuperType_Succeeds()
+    {
+        string jsonString = @"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Manager"",
+            ""department"": ""ENGINEERING"",
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""budget"": 1.00,
+            ""$identifier"": ""test@example.com""
+        }";
+
+        Manager employee = (Manager) JsonConvert.DeserializeObject<Employee>(jsonString, options);
+        
+
+        employee.ToExpectedObject().ShouldEqual(new Manager()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123",
+            budget = 1
+        });
+
+        // Should not throw
+        Manager manager = (Manager) employee;
+    }
+
+    [Fact]
+    public void MissingTypeCannotBeDeserialized()
+    {
+        string jsonString = @"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Foo""
+        }";
+
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+ 
+        Assert.Equal("Type definition `org.accordproject.concerto.test@1.2.3.Foo` not found.", ex.Message);
+    }
+
+    [Fact]
+    public void ScalarTypeCannotBeDeserialized()
+    {
+        string jsonString = "true";
+
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+
+        Assert.Equal("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft.", ex.Message);
+    }
+
+    [Fact]
+    public void MissingClassProperty()
+    {
+        string jsonString = @"{
+            ""department"": ""ENGINEERING"",
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }";
+
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+ 
+        Assert.Equal("JSON Object is missing `$class` property.", ex.Message);
+    }
+
+    [Fact]
+    public void PolymorphicObject_Succeeds()
+    {
+        string jsonStringWithManager = @"
+        {
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+            ""department"": ""ENGINEERING"",
+            ""manager"": {
+                ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+                ""email"": ""test@example.com"",
+                ""firstName"": ""Martin"",
+                ""lastName"": ""Halford"",
+                ""$identifier"": ""test@example.com"",
+                ""employeeId"": ""456""
+            },
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }";
+
+        var employee = JsonConvert.DeserializeObject<Employee>(jsonStringWithManager, options).ToExpectedObject();
+        
+        employee.ShouldEqual(new Employee()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123",
+            manager = new Employee(){
+                email = "test@example.com",
+                _identifier = "test@example.com",
+                employeeId = "456",
+                firstName = "Martin",
+                lastName = "Halford",
+            }
+        });
+    }
+
+    // Not yet implemented
+    // [Fact]
+    // public void NotSubType_Fails()
+    // {
+    //     string jsonString = @"
+    //     {
+    //        // TODO
+    //     }";
+
+    //      var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+ 
+    //     Assert.Equal("JSON Object is missing `$class` property.", ex.Message);
+
+    // }
+}

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests;
+
+using System;
+using AccordProject.Concerto.Metamodel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+public class ConcertoConverterNewtonsoftMetamodelTests
+{
+
+    JsonSerializerSettings options = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore,
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        Converters =
+        {
+            new StringEnumConverter(),
+        }
+    };
+
+    [Fact]
+    public void Roundtrip()
+    {
+        var carVIN = new StringProperty()
+        {
+            name = "vin"
+        };
+
+        var carConcept = new ConceptDeclaration()
+        {
+            name = "Car",
+            isAbstract = false,
+            properties = new StringProperty[1] { carVIN }
+        };
+
+        var carModel = new Model()
+        {
+            _namespace = "org.acme",
+            declarations = new ConceptDeclaration[1] { carConcept },
+        };
+
+        var jsonString = JsonConvert.SerializeObject(carModel, options);
+        Model model2 = JsonConvert.DeserializeObject<Model>(jsonString, options);
+        ConceptDeclaration car2 = (ConceptDeclaration) model2.declarations[0];
+        StringProperty prop = (StringProperty)((ConceptDeclaration)car2).properties[0];
+        Assert.Equal(prop._class,"concerto.metamodel@1.0.0.StringProperty");
+    }
+
+    [Fact]
+    public void Patent()
+    {
+        string jsonString = System.IO.File.ReadAllText(@"./../../../data/patent.json");
+        Model model = JsonConvert.DeserializeObject<Model>(jsonString, options);
+        // var jsonString2 = JsonConvert.SerializeObject(model, options);
+        // Console.WriteLine(jsonString2);
+    }
+}

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests;
+
+using System.Text.RegularExpressions;
+using AccordProject.Concerto;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+public class ConcertoConverterNewtonsoftSerializeTests
+{
+    JsonSerializerSettings options = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore,
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        Converters =
+        {
+            new StringEnumConverter(),
+        }
+    };
+
+    [Fact]
+    public void SimpleObject()
+    {
+        Employee employee = new Employee()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123"
+        };
+
+        string jsonString = JsonConvert.SerializeObject(employee, options);
+
+        Assert.Equal(Regex.Replace(@"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+            ""department"": ""ENGINEERING"",
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }", @"\s+", ""), jsonString);
+    }
+
+    [Fact]
+    public void ComplexObject()
+    {
+        Employee employee = new Employee()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123",
+            manager = new Employee(){
+                email = "test@example.com",
+                employeeId = "456",
+                firstName = "Martin",
+                lastName = "Halford",
+            }
+        };
+
+        string jsonString = JsonConvert.SerializeObject(employee, options);
+        Assert.Equal(Regex.Replace(@"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+            ""department"": ""ENGINEERING"",
+            ""manager"": {
+                ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+                ""employeeId"": ""456"",
+                ""email"": ""test@example.com"",
+                ""firstName"": ""Martin"",
+                ""lastName"": ""Halford""
+            },
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }", @"\s+", ""), jsonString);
+    }
+
+    [Fact]
+    public void PolymorphicObject()
+    {
+        Employee employee = new Employee()
+        {
+            firstName = "Matt",
+            lastName = "Roberts",
+            email = "test@example.com",
+            _identifier = "test@example.com",
+            department = Department.ENGINEERING,
+            employeeId = "123",
+            manager = new Manager(){
+                email = "test@example.com",
+                employeeId = "456",
+                firstName = "Martin",
+                lastName = "Halford",
+                budget = 500000
+            }
+        };
+
+        string jsonString = JsonConvert.SerializeObject(employee, options);
+        Assert.Equal(Regex.Replace(@"{
+            ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+            ""department"": ""ENGINEERING"",
+            ""manager"": {
+                ""$class"": ""org.accordproject.concerto.test@1.2.3.Manager"",
+                ""budget"": 500000.0,
+                ""employeeId"": ""456"",
+                ""email"": ""test@example.com"",
+                ""firstName"": ""Martin"",
+                ""lastName"": ""Halford""
+            },
+            ""employeeId"": ""123"",
+            ""email"": ""test@example.com"",
+            ""firstName"": ""Matt"",
+            ""lastName"": ""Roberts"",
+            ""$identifier"": ""test@example.com""
+        }", @"\s+", ""), jsonString);
+    }
+}

--- a/AccordProject.Concerto.Tests/TestTypes.cs
+++ b/AccordProject.Concerto.Tests/TestTypes.cs
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto.Tests {
+   using AccordProject.Concerto;
+   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Person")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+   public abstract class Person : Participant {
+      [Newtonsoft.Json.JsonProperty("$class")]
+		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Person";
+      public string email { get; set; }
+      public string firstName { get; set; }
+      public string lastName { get; set; }
+   }
+   public enum Department {
+      MARKETING,
+      SALES,
+      ENGINEERING,
+      OPERATIONS,
+   }
+
+   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Employee")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+   public class Employee : Person {
+      [Newtonsoft.Json.JsonProperty("$class")]
+		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Employee";
+      public Department? department { get; set; }
+      public Employee manager { get; set; }
+      public string employeeId { get; set; }
+   }
+   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Manager")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+   public class Manager : Employee {
+      [Newtonsoft.Json.JsonProperty("$class")]
+		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Manager";
+      public float budget { get; set; }
+   }
+}

--- a/AccordProject.Concerto.Tests/data/employee.cto
+++ b/AccordProject.Concerto.Tests/data/employee.cto
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@DotNetNamespace("AccordProject.Concerto.Tests")
+namespace org.accordproject.concerto.test@1.2.3
+
+abstract participant Person {
+    o String email
+    o String firstName
+    o String lastName
+}
+
+enum Department {
+    o MARKETING
+    o SALES
+    o ENGINEERING
+    o OPERATIONS
+}
+
+participant Employee identified by employeeId extends Person  {
+    o Department department optional
+    --> Employee manager optional
+    o String employeeId
+}
+
+participant Manager extends Employee  {
+    o Double budget optional
+}

--- a/AccordProject.Concerto.Tests/data/patent.cto
+++ b/AccordProject.Concerto.Tests/data/patent.cto
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.patent
+
+import org.accordproject.address.PostalAddress from https://models.accordproject.org/address.cto
+import org.accordproject.geo.Country from https://models.accordproject.org/geo.cto
+import org.accordproject.geo.GeoCoordinates from https://models.accordproject.org/geo.cto
+import org.accordproject.person.Person from https://models.accordproject.org/person.cto
+import org.accordproject.usa.residency.Residency from https://models.accordproject.org/usa/residency.cto
+
+/** 
+ * This smart-contract model describes a United States (US) patent asset that may or may not have foreign counterparts
+ * Drafted by Perkins-Coie
+ */
+
+/**
+ * A Patent Asset Identifier
+ */
+concept PatentAssetIdentifier {
+  o String assetNumber 
+  o AssetNumberStatus numberStatus
+  o Country assetCountry optional 
+}
+/**
+ * A Patent Classifier
+ */
+concept PatentClassification {
+  o String classificationSymbol optional
+  o String classificationDescription optional
+}
+
+/**
+ * An Inventor
+ */
+participant Inventor extends Person {
+  o Country residentCountry optional
+  o Residency inventorResidency optional
+}
+/**
+ * An Applicant
+ */
+participant Applicant extends Person {
+}
+
+/**
+ * An Assignee
+ */
+participant Assignee extends Person {
+}
+
+// AssetNumberStatus
+enum AssetNumberStatus {
+   o APP    // Application 
+   o PAT    // Patent 
+   o PUB    // Publication  
+   o REISS  // Reissue 
+   o FOR    // Foreign
+}
+
+// ApplicationType
+enum ApplicationType {
+   o PROV   // Provisional
+   o NONPROV    // Nonprovisional
+}
+// SubjectMatter
+enum SubjectMatter {
+   o UTILITY    // Utility
+   o PLANT  // Plant
+   o DESIGN     // Design
+}
+/**
+ * http://schema.org/PatentAsset
+ */
+concept PatentAsset {
+  o PatentAssetIdentifier[] assetIdentifier
+  o String title optional
+  o Inventor[] inventorIdentifier optional
+  o Applicant applicantIdentifier optional
+  o Assignee currentAssignee optional
+  o Assignee originalAssignee optional
+  o DateTime priorityDate optional
+  o DateTime filingDate optional
+  o DateTime issueDate optional
+  o DateTime publicationDate optional
+  o PatentClassification[] classifier optional
+  o String attorneyDocketNumber optional
+  o String customerNumber optional
+  o String[] emailAddress optional
+  o ApplicationType applicationType optional
+  o SubjectMatter subjectMatter optional
+  o Double numDrawings optional
+  o Double pubFigure optional
+  o PatentAsset[] priorApplication optional
+}

--- a/AccordProject.Concerto.Tests/data/patent.json
+++ b/AccordProject.Concerto.Tests/data/patent.json
@@ -1,0 +1,1032 @@
+{
+  "$class": "concerto.metamodel@1.0.0.Model",
+  "decorators": [],
+  "namespace": "org.accordproject.patent",
+  "imports": [
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportType",
+      "name": "PostalAddress",
+      "namespace": "org.accordproject.address",
+      "uri": "https://models.accordproject.org/address.cto"
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportType",
+      "name": "Country",
+      "namespace": "org.accordproject.geo",
+      "uri": "https://models.accordproject.org/geo.cto"
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportType",
+      "name": "GeoCoordinates",
+      "namespace": "org.accordproject.geo",
+      "uri": "https://models.accordproject.org/geo.cto"
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportType",
+      "name": "Person",
+      "namespace": "org.accordproject.person",
+      "uri": "https://models.accordproject.org/person.cto"
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportType",
+      "name": "Residency",
+      "namespace": "org.accordproject.usa.residency",
+      "uri": "https://models.accordproject.org/usa/residency.cto"
+    }
+  ],
+  "declarations": [
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "PatentAssetIdentifier",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "assetNumber",
+          "isArray": false,
+          "isOptional": false,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1286,
+              "line": 32,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1310,
+              "line": 33,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "numberStatus",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "AssetNumberStatus"
+          },
+          "isArray": false,
+          "isOptional": false,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1310,
+              "line": 33,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1345,
+              "line": 34,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "assetCountry",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Country"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1345,
+              "line": 34,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1378,
+              "line": 35,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1252,
+          "line": 31,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1379,
+          "line": 35,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "PatentClassification",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "classificationSymbol",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1444,
+              "line": 40,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1485,
+              "line": 41,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "classificationDescription",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1485,
+              "line": 41,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1529,
+              "line": 42,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1411,
+          "line": 39,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1530,
+          "line": 42,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ParticipantDeclaration",
+      "name": "Inventor",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "residentCountry",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Country"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1595,
+              "line": 48,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1632,
+              "line": 49,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "inventorResidency",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Residency"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1632,
+              "line": 49,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1671,
+              "line": 50,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1555,
+          "line": 47,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1672,
+          "line": 50,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      },
+      "superType": {
+        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+        "name": "Person"
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ParticipantDeclaration",
+      "name": "Applicant",
+      "isAbstract": false,
+      "properties": [],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1697,
+          "line": 54,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1737,
+          "line": 55,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      },
+      "superType": {
+        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+        "name": "Person"
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ParticipantDeclaration",
+      "name": "Assignee",
+      "isAbstract": false,
+      "properties": [],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1762,
+          "line": 60,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1801,
+          "line": 61,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      },
+      "superType": {
+        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+        "name": "Person"
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.EnumDeclaration",
+      "name": "AssetNumberStatus",
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "APP",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1852,
+              "line": 65,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1880,
+              "line": 66,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "PAT",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1880,
+              "line": 66,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1903,
+              "line": 67,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "PUB",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1903,
+              "line": 67,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1932,
+              "line": 68,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "REISS",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1932,
+              "line": 68,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1956,
+              "line": 69,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "FOR",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 1956,
+              "line": 69,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 1976,
+              "line": 70,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1824,
+          "line": 64,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 1977,
+          "line": 70,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.EnumDeclaration",
+      "name": "ApplicationType",
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "PROV",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2024,
+              "line": 74,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2051,
+              "line": 75,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "NONPROV",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2051,
+              "line": 75,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2082,
+              "line": 76,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 1998,
+          "line": 73,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 2083,
+          "line": 76,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.EnumDeclaration",
+      "name": "SubjectMatter",
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "UTILITY",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2125,
+              "line": 79,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2152,
+              "line": 80,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "PLANT",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2152,
+              "line": 80,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2173,
+              "line": 81,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.EnumProperty",
+          "name": "DESIGN",
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2173,
+              "line": 81,
+              "column": 4,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2196,
+              "line": 82,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 2101,
+          "line": 78,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 2197,
+          "line": 82,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "PatentAsset",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "assetIdentifier",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "PatentAssetIdentifier"
+          },
+          "isArray": true,
+          "isOptional": false,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2263,
+              "line": 87,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2307,
+              "line": 88,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "title",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2307,
+              "line": 88,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2333,
+              "line": 89,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "inventorIdentifier",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Inventor"
+          },
+          "isArray": true,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2333,
+              "line": 89,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2376,
+              "line": 90,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "applicantIdentifier",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Applicant"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2376,
+              "line": 90,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2419,
+              "line": 91,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "currentAssignee",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Assignee"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2419,
+              "line": 91,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2457,
+              "line": 92,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "originalAssignee",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Assignee"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2457,
+              "line": 92,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2496,
+              "line": 93,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+          "name": "priorityDate",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2496,
+              "line": 93,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2531,
+              "line": 94,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+          "name": "filingDate",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2531,
+              "line": 94,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2564,
+              "line": 95,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+          "name": "issueDate",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2564,
+              "line": 95,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2596,
+              "line": 96,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DateTimeProperty",
+          "name": "publicationDate",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2596,
+              "line": 96,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2634,
+              "line": 97,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "classifier",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "PatentClassification"
+          },
+          "isArray": true,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2634,
+              "line": 97,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2681,
+              "line": 98,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "attorneyDocketNumber",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2681,
+              "line": 98,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2722,
+              "line": 99,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "customerNumber",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2722,
+              "line": 99,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2757,
+              "line": 100,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "emailAddress",
+          "isArray": true,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2757,
+              "line": 100,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2792,
+              "line": 101,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "applicationType",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "ApplicationType"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2792,
+              "line": 101,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2837,
+              "line": 102,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "subjectMatter",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "SubjectMatter"
+          },
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2837,
+              "line": 102,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2878,
+              "line": 103,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+          "name": "numDrawings",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2878,
+              "line": 103,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2910,
+              "line": 104,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+          "name": "pubFigure",
+          "isArray": false,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2910,
+              "line": 104,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2940,
+              "line": 105,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "priorApplication",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "PatentAsset"
+          },
+          "isArray": true,
+          "isOptional": true,
+          "location": {
+            "$class": "concerto.metamodel@1.0.0.Range",
+            "start": {
+              "offset": 2940,
+              "line": 105,
+              "column": 3,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            },
+            "end": {
+              "offset": 2982,
+              "line": 106,
+              "column": 1,
+              "$class": "concerto.metamodel@1.0.0.Position"
+            }
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@1.0.0.Range",
+        "start": {
+          "offset": 2239,
+          "line": 86,
+          "column": 1,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        },
+        "end": {
+          "offset": 2983,
+          "line": 106,
+          "column": 2,
+          "$class": "concerto.metamodel@1.0.0.Position"
+        }
+      }
+    }
+  ]
+}

--- a/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
+++ b/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AccordProject.Concerto;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public class ConcertoConverterNewtonsoft : JsonConverter
+{
+    public override bool CanRead => true;
+
+    public override bool CanWrite => false;
+
+    public override bool CanConvert(Type t) => t.IsAssignableTo(typeof(Concept));
+
+    public override void WriteJson(JsonWriter writer, Object? value, JsonSerializer serializer)
+    {
+        // The default Newtonsoft behaviour is acceptable.
+        // This method will never be called as CanWrite is always false.
+        throw new NotImplementedException();
+    }
+
+    public override Object ReadJson(JsonReader reader, Type objectType, Object? existingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new JsonException("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft.");
+        }
+
+        // Peek ahead at the object
+        var jsonObject = JObject.Load(reader);
+
+        // All Concerto documents must have a `$class` property
+        string? clazz = jsonObject["$class"]?.Value<string>();
+        if (clazz == null)
+        {
+            throw new JsonException("JSON Object is missing `$class` property.");
+        }
+
+        // Find the type from the dictionary that corresponds to the $class discriminator
+        var declaredType = ConcertoTypeDictionary.Instance.ResolveType(clazz);
+        if (declaredType == null)
+        {
+            throw new JsonException("Type definition `" + clazz + "` not found.");
+        }
+
+        // Allow a more specified type to be provided instead of the type from the C# class
+        Type actualType;
+        if (objectType == declaredType)
+        {
+            actualType = objectType;
+        }
+        else if (declaredType.IsAssignableTo(objectType))
+        {
+            // The declared type in the JSON is a subtype of the object type in the .NET class.
+            actualType = declaredType;
+        }
+        else
+        {
+            throw new JsonException("Invalid type declaration. `" + declaredType + "` is not a valid subtype of the expected `" + objectType + "`.");
+        }
+
+        var target = Activator.CreateInstance(actualType);
+        if (target == null)
+        {
+            throw new JsonException("Failed to create instance of `" + actualType + "`.");
+        }
+        serializer.Populate(jsonObject.CreateReader(), target);
+        return target;
+    }
+}

--- a/AccordProject.Concerto/ConcertoMetamodelTypes.cs
+++ b/AccordProject.Concerto/ConcertoMetamodelTypes.cs
@@ -12,110 +12,122 @@
  * limitations under the License.
  */
 
-using System;
-using System.Text.Json.Serialization;
-
 namespace AccordProject.Concerto.Metamodel {
    using AccordProject.Concerto;
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Position")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Position : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Position";
       public int line { get; set; }
       public int column { get; set; }
       public int offset { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Range")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Range : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Range";
       public Position start { get; set; }
       public Position end { get; set; }
       public string source { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TypeIdentifier")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class TypeIdentifier : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.TypeIdentifier";
       public string name { get; set; }
-      [JsonPropertyName("namespace")]
+      [Newtonsoft.Json.JsonProperty("namespace")]
 		public string _namespace { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorLiteral")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class DecoratorLiteral : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorLiteral";
       public Range location { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorString")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DecoratorString : DecoratorLiteral {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorString";
       public string value { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorNumber")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DecoratorNumber : DecoratorLiteral {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorNumber";
       public float value { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorBoolean")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DecoratorBoolean : DecoratorLiteral {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorBoolean";
       public bool value { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorTypeReference")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DecoratorTypeReference : DecoratorLiteral {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorTypeReference";
       public TypeIdentifier type { get; set; }
       public bool isArray { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Decorator")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Decorator : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Decorator";
       public string name { get; set; }
       public DecoratorLiteral[] arguments { get; set; }
       public Range location { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Identified")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Identified : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Identified";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IdentifiedBy")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class IdentifiedBy : Identified {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IdentifiedBy";
       public string name { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Declaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Declaration : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Declaration";
       public string name { get; set; }
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class EnumDeclaration : Declaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumDeclaration";
       public EnumProperty[] properties { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class EnumProperty : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumProperty";
       public string name { get; set; }
       public Decorator[] decorators { get; set; }
       public Range location { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ConceptDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ConceptDeclaration : Declaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ConceptDeclaration";
       public bool isAbstract { get; set; }
       public Identified identified { get; set; }
@@ -123,28 +135,33 @@ namespace AccordProject.Concerto.Metamodel {
       public Property[] properties { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "AssetDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class AssetDeclaration : ConceptDeclaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.AssetDeclaration";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ParticipantDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ParticipantDeclaration : ConceptDeclaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ParticipantDeclaration";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TransactionDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class TransactionDeclaration : ConceptDeclaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.TransactionDeclaration";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EventDeclaration")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class EventDeclaration : ConceptDeclaration {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.EventDeclaration";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Property")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Property : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Property";
       public string name { get; set; }
       public bool isArray { get; set; }
@@ -153,115 +170,132 @@ namespace AccordProject.Concerto.Metamodel {
       public Range location { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "RelationshipProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class RelationshipProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.RelationshipProperty";
       public TypeIdentifier type { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ObjectProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ObjectProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ObjectProperty";
       public string defaultValue { get; set; }
       public TypeIdentifier type { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "BooleanProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class BooleanProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.BooleanProperty";
       public bool defaultValue { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DateTimeProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DateTimeProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DateTimeProperty";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class StringProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.StringProperty";
       public string defaultValue { get; set; }
       public StringRegexValidator validator { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringRegexValidator")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class StringRegexValidator : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.StringRegexValidator";
       public string pattern { get; set; }
       public string flags { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DoubleProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleProperty";
       public float defaultValue { get; set; }
       public DoubleDomainValidator validator { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleDomainValidator")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class DoubleDomainValidator : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleDomainValidator";
       public float lower { get; set; }
       public float upper { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class IntegerProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerProperty";
       public int defaultValue { get; set; }
       public IntegerDomainValidator validator { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerDomainValidator")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class IntegerDomainValidator : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerDomainValidator";
       public int lower { get; set; }
       public int upper { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongProperty")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class LongProperty : Property {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.LongProperty";
       public long defaultValue { get; set; }
       public LongDomainValidator validator { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongDomainValidator")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class LongDomainValidator : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.LongDomainValidator";
       public long lower { get; set; }
       public long upper { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Import")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Import : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Import";
-      [JsonPropertyName("namespace")]
+      [Newtonsoft.Json.JsonProperty("namespace")]
 		public string _namespace { get; set; }
       public string uri { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportAll")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ImportAll : Import {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportAll";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportType")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ImportType : Import {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportType";
       public string name { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportTypes")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class ImportTypes : Import {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportTypes";
       public string[] types { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Model")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Model : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Model";
-      [JsonPropertyName("namespace")]
+      [Newtonsoft.Json.JsonProperty("namespace")]
 		public string _namespace { get; set; }
       public string sourceUri { get; set; }
       public string concertoVersion { get; set; }
@@ -270,8 +304,9 @@ namespace AccordProject.Concerto.Metamodel {
       public Decorator[] decorators { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Models")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public class Models : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto.metamodel@1.0.0.Models";
       public Model[] models { get; set; }
    }

--- a/AccordProject.Concerto/ConcertoTypes.cs
+++ b/AccordProject.Concerto/ConcertoTypes.cs
@@ -12,41 +12,43 @@
  * limitations under the License.
  */
 
-using System;
-using System.Text.Json.Serialization;
-
 namespace AccordProject.Concerto {
    [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public virtual string _class { get; } = "concerto@1.0.0.Concept";
    }
    [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Asset")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Asset : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Asset";
-      [JsonPropertyName("$identifier")]
+      [Newtonsoft.Json.JsonProperty("$identifier")]
 		public string _identifier { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Participant")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Participant : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Participant";
-      [JsonPropertyName("$identifier")]
+      [Newtonsoft.Json.JsonProperty("$identifier")]
 		public string _identifier { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Transaction")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Transaction : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Transaction";
-      [JsonPropertyName("$timestamp")]
-		public DateTime _timestamp { get; set; }
+      [Newtonsoft.Json.JsonProperty("$timestamp")]
+		public System.DateTime _timestamp { get; set; }
    }
    [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Event")]
+   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
    public abstract class Event : Concept {
-      [JsonPropertyName("$class")]
+      [Newtonsoft.Json.JsonProperty("$class")]
 		public override string _class { get; } = "concerto@1.0.0.Event";
-      [JsonPropertyName("$timestamp")]
-		public DateTime _timestamp { get; set; }
+      [Newtonsoft.Json.JsonProperty("$timestamp")]
+		public System.DateTime _timestamp { get; set; }
    }
 }


### PR DESCRIPTION
This change adds the Newtonsoft converter which will handle polymorphic deserialization using the Concerto type system. Serialization is not implemented as the default serialization behaviour provided by Newtonsoft is fine.

The Newtonsoft converter should be specified on all Concerto classes with the following attribute:

```
[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
```

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>