### PR TITLE
feat(*): codegen scripts, remove enum converter

### DIFF
--- a/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
+++ b/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\AccordProject.Concerto\AccordProject.Concerto.csproj" />
   </ItemGroup>
 
+  <Target Name="Codegen" BeforeTargets="PreBuildEvent">
+    <Exec Command="bash scripts/codegen.sh" />
+  </Target>
+
 </Project>

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
@@ -25,10 +25,6 @@ public class ConcertoConverterNewtonsoftDeserializeTests
     {
         NullValueHandling = NullValueHandling.Ignore,
         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-        Converters =
-        {
-            new StringEnumConverter(),
-        }
     };
 
     [Fact]

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
@@ -26,10 +26,6 @@ public class ConcertoConverterNewtonsoftMetamodelTests
     {
         NullValueHandling = NullValueHandling.Ignore,
         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-        Converters =
-        {
-            new StringEnumConverter(),
-        }
     };
 
     [Fact]

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
@@ -25,10 +25,6 @@ public class ConcertoConverterNewtonsoftSerializeTests
     {
         NullValueHandling = NullValueHandling.Ignore,
         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-        Converters =
-        {
-            new StringEnumConverter(),
-        }
     };
 
     [Fact]

--- a/AccordProject.Concerto.Tests/TestTypes.cs
+++ b/AccordProject.Concerto.Tests/TestTypes.cs
@@ -23,6 +23,7 @@ namespace AccordProject.Concerto.Tests {
       public string firstName { get; set; }
       public string lastName { get; set; }
    }
+   [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
    public enum Department {
       MARKETING,
       SALES,

--- a/AccordProject.Concerto.Tests/scripts/codegen.sh
+++ b/AccordProject.Concerto.Tests/scripts/codegen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -d output ]; then
+    rm -rf output
+fi
+npx --yes @accordproject/concerto-cli@unstable parse --model data/patent.cto --output data/patent.json
+npx --yes @accordproject/concerto-cli@unstable compile --model data/employee.cto --target CSharp --strict --useNewtonsoftJson
+mv output/org.accordproject.concerto.test@1.2.3.cs TestTypes.cs
+rm -rf output

--- a/AccordProject.Concerto/AccordProject.Concerto.csproj
+++ b/AccordProject.Concerto/AccordProject.Concerto.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
+  <Target Name="Codegen" BeforeTargets="PreBuildEvent">
+    <Exec Command="bash scripts/codegen.sh" />
+  </Target>
+
 </Project>

--- a/AccordProject.Concerto/scripts/codegen.sh
+++ b/AccordProject.Concerto/scripts/codegen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -d output ]; then
+    rm -rf output
+fi
+npx @accordproject/concerto-cli@unstable compile --metamodel --target CSharp --strict --useNewtonsoftJson
+cp output/concerto@1.0.0.cs ConcertoTypes.cs
+cp output/concerto.metamodel@1.0.0.cs ConcertoMetamodelTypes.cs
+rm -rf output


### PR DESCRIPTION
Add scripts for code generation using the Concerto CLI, and automate them as pre-build targets.

Remove the explicit enum converter as this is now specified via code generation.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>