### PR TITLE
feat(*): add namespace parser util

### DIFF
--- a/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
@@ -20,6 +20,41 @@ using AccordProject.Concerto;
 public class ConcertoUtilsTests
 {
     [Fact]
+    public void CanParseUnversionedNamespace()
+    {
+        var expected = new ConcertoNamespace() {
+            Namespace = "org.example",
+        }.ToExpectedObject();
+        var actual = ConcertoUtils.ParseNamespace("org.example");
+        expected.ShouldEqual(actual);
+    }
+
+    [Fact]
+    public void CanParseVersionedNamespace()
+    {
+        var expected = new ConcertoNamespace() {
+            Namespace = "org.example",
+            Version = "1.2.3"
+        }.ToExpectedObject();
+        var actual = ConcertoUtils.ParseNamespace("org.example@1.2.3");
+        expected.ShouldEqual(actual);
+    }
+         
+    [Fact]
+    public void CannotParseNamespaceWithEmptyNamespace()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseNamespace(""));
+        Assert.Equal("Invalid namespace \"\"", ex.Message);
+    }
+         
+    [Fact]
+    public void CannotParseNamespaceWithEmptyVersion()
+    {
+        var ex = Assert.Throws<Exception>(() => ConcertoUtils.ParseNamespace("org.example@"));
+        Assert.Equal("Invalid namespace \"org.example@\"", ex.Message);
+    }
+
+    [Fact]
     public void CanParseUnversionedType()
     {
         var expected = new ConcertoType() {

--- a/AccordProject.Concerto/ConcertoUtils.cs
+++ b/AccordProject.Concerto/ConcertoUtils.cs
@@ -15,6 +15,21 @@
 /// <summary>
 /// This class represents a Concerto type, for example org.example@1.2.3.Foo.
 /// </summary>
+public struct ConcertoNamespace
+{
+    public string Namespace { get; init; }
+    public string? Version { get; init; }
+
+    public override string ToString()
+    {
+        if (Version != null)
+        {
+            return $"{Namespace}@{Version}";
+        }
+        return Namespace;
+    }
+}
+
 public struct ConcertoType
 {
     public string Namespace { get; init; }
@@ -36,6 +51,31 @@ public struct ConcertoType
 /// </summary>
 public class ConcertoUtils
 {
+    public static ConcertoNamespace ParseNamespace(string ns)
+    {
+        string parsedNamespace;
+        string? parsedVersion;
+        int i = ns.IndexOf("@");
+        if (i != -1)
+        {
+            parsedNamespace = ns[..i];
+            parsedVersion =  ns[(i + 1)..];
+        }
+        else
+        {
+            parsedNamespace = ns;
+        }
+        if (parsedNamespace.Length == 0 || parsedVersion?.Length == 0)
+        {
+            throw new Exception($"Invalid namespace \"{ns}\"");
+        }
+        return new ConcertoNamespace()
+        {
+            Namespace = parsedNamespace,
+            Version = parsedVersion
+        };
+    }
+
     public static ConcertoType ParseType(string fqn)
     {
         int i = fqn.LastIndexOf(".");


### PR DESCRIPTION
Add a utility function that can parse a Concerto namespace reference, e.g. `org.example@1.2.3`.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>