### PR TITLE
chore(*): extend deserialization error message

### DIFF
--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
@@ -104,7 +104,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
 
         var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
 
-        Assert.Equal("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft.", ex.Message);
+        Assert.Equal("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft, current token is Boolean.", ex.Message);
     }
 
     [Fact]

--- a/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
+++ b/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
@@ -36,7 +36,7 @@ public class ConcertoConverterNewtonsoft : JsonConverter
     {
         if (reader.TokenType != JsonToken.StartObject)
         {
-            throw new JsonException("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft.");
+            throw new JsonException($"Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft, current token is {reader.TokenType}.");
         }
 
         // Peek ahead at the object


### PR DESCRIPTION
Improve the "not a JSON object" error message with the token that was actually encountered to improve debugging.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>