### PR TITLE
chore(*): enable source link for debugging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Pack
         run: |
           dotnet pack AccordProject.Concerto.sln --configuration Release --no-restore /p:Version=${{ github.event.release.tag_name }}
-          dotnet pack AccordProject.Concerto.sln --configuration Release --no-restore /p:Version=${{ github.event.release.tag_name }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
       - name: Nuget Push
         run: |
           dotnet nuget push AccordProject.Concerto/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_KEY }}

--- a/AccordProject.Concerto/AccordProject.Concerto.csproj
+++ b/AccordProject.Concerto/AccordProject.Concerto.csproj
@@ -4,9 +4,17 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Enable Source Link (https://github.com/dotnet/sourcelink) which embeds references to the source code on GitHub in the symbol files so that IDEs can discover the source. At the same time, remove my workflow change from the previous PR as this can be turned on in the project settings, which means we will always get `.snupkg` files.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>