### PR TITLE
fix(*): handle null values in custom json converter

### DIFF
--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
@@ -21,12 +21,6 @@ using Newtonsoft.Json.Converters;
 
 public class ConcertoConverterNewtonsoftDeserializeTests
 {
-    JsonSerializerSettings options = new()
-    {
-        NullValueHandling = NullValueHandling.Ignore,
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-    };
-
     [Fact]
     public void SimpleObject_Succeeds()
     {
@@ -40,7 +34,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
             ""$identifier"": ""test@example.com""
         }";
 
-        var employee = JsonConvert.DeserializeObject<Employee>(jsonString, options).ToExpectedObject();
+        var employee = JsonConvert.DeserializeObject<Employee>(jsonString).ToExpectedObject();
 
         employee.ShouldEqual(new Employee()
         {
@@ -67,7 +61,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
             ""$identifier"": ""test@example.com""
         }";
 
-        Manager employee = (Manager) JsonConvert.DeserializeObject<Employee>(jsonString, options);
+        Manager employee = (Manager) JsonConvert.DeserializeObject<Employee>(jsonString);
         
 
         employee.ToExpectedObject().ShouldEqual(new Manager()
@@ -92,7 +86,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
             ""$class"": ""org.accordproject.concerto.test@1.2.3.Foo""
         }";
 
-        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString));
  
         Assert.Equal("Type definition `org.accordproject.concerto.test@1.2.3.Foo` not found.", ex.Message);
     }
@@ -102,7 +96,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
     {
         string jsonString = "true";
 
-        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString));
 
         Assert.Equal("Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft, current token is Boolean.", ex.Message);
     }
@@ -119,7 +113,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
             ""$identifier"": ""test@example.com""
         }";
 
-        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+        var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString));
  
         Assert.Equal("JSON Object is missing `$class` property.", ex.Message);
     }
@@ -146,7 +140,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
             ""$identifier"": ""test@example.com""
         }";
 
-        var employee = JsonConvert.DeserializeObject<Employee>(jsonStringWithManager, options).ToExpectedObject();
+        var employee = JsonConvert.DeserializeObject<Employee>(jsonStringWithManager).ToExpectedObject();
         
         employee.ShouldEqual(new Employee()
         {
@@ -175,7 +169,7 @@ public class ConcertoConverterNewtonsoftDeserializeTests
     //        // TODO
     //     }";
 
-    //      var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString, options));
+    //      var ex = Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<Employee>(jsonString));
  
     //     Assert.Equal("JSON Object is missing `$class` property.", ex.Message);
 

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
@@ -21,13 +21,6 @@ using Newtonsoft.Json.Converters;
 
 public class ConcertoConverterNewtonsoftMetamodelTests
 {
-
-    JsonSerializerSettings options = new()
-    {
-        NullValueHandling = NullValueHandling.Ignore,
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-    };
-
     [Fact]
     public void Roundtrip()
     {
@@ -49,8 +42,8 @@ public class ConcertoConverterNewtonsoftMetamodelTests
             declarations = new ConceptDeclaration[1] { carConcept },
         };
 
-        var jsonString = JsonConvert.SerializeObject(carModel, options);
-        Model model2 = JsonConvert.DeserializeObject<Model>(jsonString, options);
+        var jsonString = JsonConvert.SerializeObject(carModel);
+        Model model2 = JsonConvert.DeserializeObject<Model>(jsonString);
         ConceptDeclaration car2 = (ConceptDeclaration) model2.declarations[0];
         StringProperty prop = (StringProperty)((ConceptDeclaration)car2).properties[0];
         Assert.Equal(prop._class,"concerto.metamodel@1.0.0.StringProperty");
@@ -60,7 +53,7 @@ public class ConcertoConverterNewtonsoftMetamodelTests
     public void Patent()
     {
         string jsonString = System.IO.File.ReadAllText(@"./../../../data/patent.json");
-        Model model = JsonConvert.DeserializeObject<Model>(jsonString, options);
+        Model model = JsonConvert.DeserializeObject<Model>(jsonString);
         // var jsonString2 = JsonConvert.SerializeObject(model, options);
         // Console.WriteLine(jsonString2);
     }

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
@@ -21,12 +21,6 @@ using Newtonsoft.Json.Converters;
 
 public class ConcertoConverterNewtonsoftSerializeTests
 {
-    JsonSerializerSettings options = new()
-    {
-        NullValueHandling = NullValueHandling.Ignore,
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-    };
-
     [Fact]
     public void SimpleObject()
     {
@@ -40,11 +34,12 @@ public class ConcertoConverterNewtonsoftSerializeTests
             employeeId = "123"
         };
 
-        string jsonString = JsonConvert.SerializeObject(employee, options);
+        string jsonString = JsonConvert.SerializeObject(employee);
 
         Assert.Equal(Regex.Replace(@"{
             ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
             ""department"": ""ENGINEERING"",
+            ""manager"": null,
             ""employeeId"": ""123"",
             ""email"": ""test@example.com"",
             ""firstName"": ""Matt"",
@@ -72,16 +67,19 @@ public class ConcertoConverterNewtonsoftSerializeTests
             }
         };
 
-        string jsonString = JsonConvert.SerializeObject(employee, options);
+        string jsonString = JsonConvert.SerializeObject(employee);
         Assert.Equal(Regex.Replace(@"{
             ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
             ""department"": ""ENGINEERING"",
             ""manager"": {
                 ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
+                ""department"": null,
+                ""manager"": null,
                 ""employeeId"": ""456"",
                 ""email"": ""test@example.com"",
                 ""firstName"": ""Martin"",
-                ""lastName"": ""Halford""
+                ""lastName"": ""Halford"",
+                ""$identifier"": null
             },
             ""employeeId"": ""123"",
             ""email"": ""test@example.com"",
@@ -111,17 +109,20 @@ public class ConcertoConverterNewtonsoftSerializeTests
             }
         };
 
-        string jsonString = JsonConvert.SerializeObject(employee, options);
+        string jsonString = JsonConvert.SerializeObject(employee);
         Assert.Equal(Regex.Replace(@"{
             ""$class"": ""org.accordproject.concerto.test@1.2.3.Employee"",
             ""department"": ""ENGINEERING"",
             ""manager"": {
                 ""$class"": ""org.accordproject.concerto.test@1.2.3.Manager"",
                 ""budget"": 500000.0,
+                ""department"": null,
+                ""manager"": null,
                 ""employeeId"": ""456"",
                 ""email"": ""test@example.com"",
                 ""firstName"": ""Martin"",
-                ""lastName"": ""Halford""
+                ""lastName"": ""Halford"",
+                ""$identifier"": null
             },
             ""employeeId"": ""123"",
             ""email"": ""test@example.com"",

--- a/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
+++ b/AccordProject.Concerto/ConcertoConverterNewtonsoft.cs
@@ -32,9 +32,14 @@ public class ConcertoConverterNewtonsoft : JsonConverter
         throw new NotImplementedException();
     }
 
-    public override Object ReadJson(JsonReader reader, Type objectType, Object? existingValue, JsonSerializer serializer)
+    public override Object? ReadJson(JsonReader reader, Type objectType, Object? existingValue, JsonSerializer serializer)
     {
-        if (reader.TokenType != JsonToken.StartObject)
+        if (reader.TokenType == JsonToken.Null)
+        {
+            // Null values may or may not be okay depending on the model, but we cannot know here.
+            return null;
+        }
+        else if (reader.TokenType != JsonToken.StartObject)
         {
             throw new JsonException($"Only JSON Objects can be deserialized with ConcertoConverterNewtonsoft, current token is {reader.TokenType}.");
         }


### PR DESCRIPTION
The `JsonSerializerSettings` are in the control of the consuming application, which means that we cannot rely on `NullValueHandling` being set to `Ignore`. This change updates our custom JSON converter to handle null values for modelled objects instead of throwing an error message, and removes all `JsonSerializerSettings` from our tests.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>