### PR TITLE
chore(*): ensure generated code has license headers

### DIFF
--- a/AccordProject.Concerto.Tests/scripts/codegen.sh
+++ b/AccordProject.Concerto.Tests/scripts/codegen.sh
@@ -5,5 +5,5 @@ if [ -d output ]; then
 fi
 npx --yes @accordproject/concerto-cli@unstable parse --model data/patent.cto --output data/patent.json
 npx --yes @accordproject/concerto-cli@unstable compile --model data/employee.cto --target CSharp --strict --useNewtonsoftJson
-mv output/org.accordproject.concerto.test@1.2.3.cs TestTypes.cs
+cat scripts/header.txt output/org.accordproject.concerto.test@1.2.3.cs > TestTypes.cs
 rm -rf output

--- a/AccordProject.Concerto.Tests/scripts/header.txt
+++ b/AccordProject.Concerto.Tests/scripts/header.txt
@@ -1,0 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/AccordProject.Concerto/scripts/codegen.sh
+++ b/AccordProject.Concerto/scripts/codegen.sh
@@ -4,6 +4,6 @@ if [ -d output ]; then
     rm -rf output
 fi
 npx @accordproject/concerto-cli@unstable compile --metamodel --target CSharp --strict --useNewtonsoftJson
-cp output/concerto@1.0.0.cs ConcertoTypes.cs
-cp output/concerto.metamodel@1.0.0.cs ConcertoMetamodelTypes.cs
+cat scripts/header.txt output/concerto@1.0.0.cs > ConcertoTypes.cs
+cat scripts/header.txt output/concerto.metamodel@1.0.0.cs > ConcertoMetamodelTypes.cs
 rm -rf output

--- a/AccordProject.Concerto/scripts/header.txt
+++ b/AccordProject.Concerto/scripts/header.txt
@@ -1,0 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+


### PR DESCRIPTION
When we run the code generation scripts, we lose the license headers. This change updates the code generation scripts to prepend the generated code with the license headers so this is no longer a problem.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>