### PR TITLE
feat(*): use pascal case for generated c# code

### DIFF
--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftDeserializeTests.cs
@@ -38,12 +38,12 @@ public class ConcertoConverterNewtonsoftDeserializeTests
 
         employee.ShouldEqual(new Employee()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123"
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123"
         });
     }
 
@@ -66,13 +66,13 @@ public class ConcertoConverterNewtonsoftDeserializeTests
 
         employee.ToExpectedObject().ShouldEqual(new Manager()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123",
-            budget = 1
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123",
+            Budget = 1
         });
 
         // Should not throw
@@ -144,18 +144,18 @@ public class ConcertoConverterNewtonsoftDeserializeTests
         
         employee.ShouldEqual(new Employee()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123",
-            manager = new Employee(){
-                email = "test@example.com",
-                _identifier = "test@example.com",
-                employeeId = "456",
-                firstName = "Martin",
-                lastName = "Halford",
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123",
+            Manager = new Employee(){
+                Email = "test@example.com",
+                _Identifier = "test@example.com",
+                EmployeeId = "456",
+                FirstName = "Martin",
+                LastName = "Halford",
             }
         });
     }

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftMetamodel.cs
@@ -26,27 +26,27 @@ public class ConcertoConverterNewtonsoftMetamodelTests
     {
         var carVIN = new StringProperty()
         {
-            name = "vin"
+            Name = "vin"
         };
 
         var carConcept = new ConceptDeclaration()
         {
-            name = "Car",
-            isAbstract = false,
-            properties = new StringProperty[1] { carVIN }
+            Name = "Car",
+            IsAbstract = false,
+            Properties = new StringProperty[1] { carVIN }
         };
 
         var carModel = new Model()
         {
-            _namespace = "org.acme",
-            declarations = new ConceptDeclaration[1] { carConcept },
+            Namespace = "org.acme",
+            Declarations = new ConceptDeclaration[1] { carConcept },
         };
 
         var jsonString = JsonConvert.SerializeObject(carModel);
         Model model2 = JsonConvert.DeserializeObject<Model>(jsonString);
-        ConceptDeclaration car2 = (ConceptDeclaration) model2.declarations[0];
-        StringProperty prop = (StringProperty)((ConceptDeclaration)car2).properties[0];
-        Assert.Equal(prop._class,"concerto.metamodel@1.0.0.StringProperty");
+        ConceptDeclaration car2 = (ConceptDeclaration) model2.Declarations[0];
+        StringProperty prop = (StringProperty)((ConceptDeclaration)car2).Properties[0];
+        Assert.Equal(prop._Class,"concerto.metamodel@1.0.0.StringProperty");
     }
 
     [Fact]

--- a/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoConverterNewtonsoftSerializeTests.cs
@@ -26,12 +26,12 @@ public class ConcertoConverterNewtonsoftSerializeTests
     {
         Employee employee = new Employee()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123"
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123"
         };
 
         string jsonString = JsonConvert.SerializeObject(employee);
@@ -53,17 +53,17 @@ public class ConcertoConverterNewtonsoftSerializeTests
     {
         Employee employee = new Employee()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123",
-            manager = new Employee(){
-                email = "test@example.com",
-                employeeId = "456",
-                firstName = "Martin",
-                lastName = "Halford",
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123",
+            Manager = new Employee(){
+                Email = "test@example.com",
+                EmployeeId = "456",
+                FirstName = "Martin",
+                LastName = "Halford",
             }
         };
 
@@ -94,18 +94,18 @@ public class ConcertoConverterNewtonsoftSerializeTests
     {
         Employee employee = new Employee()
         {
-            firstName = "Matt",
-            lastName = "Roberts",
-            email = "test@example.com",
-            _identifier = "test@example.com",
-            department = Department.ENGINEERING,
-            employeeId = "123",
-            manager = new Manager(){
-                email = "test@example.com",
-                employeeId = "456",
-                firstName = "Martin",
-                lastName = "Halford",
-                budget = 500000
+            FirstName = "Matt",
+            LastName = "Roberts",
+            Email = "test@example.com",
+            _Identifier = "test@example.com",
+            Department = Department.ENGINEERING,
+            EmployeeId = "123",
+            Manager = new Manager(){
+                Email = "test@example.com",
+                EmployeeId = "456",
+                FirstName = "Martin",
+                LastName = "Halford",
+                Budget = 500000
             }
         };
 

--- a/AccordProject.Concerto.Tests/TestTypes.cs
+++ b/AccordProject.Concerto.Tests/TestTypes.cs
@@ -12,39 +12,44 @@
  * limitations under the License.
  */
 
-namespace AccordProject.Concerto.Tests {
-   using AccordProject.Concerto;
-   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Person")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Person : Participant {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Person";
-      public string email { get; set; }
-      public string firstName { get; set; }
-      public string lastName { get; set; }
-   }
-   [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-   public enum Department {
+namespace AccordProject.Concerto.Tests;
+using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Person")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Person : Participant {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "org.accordproject.concerto.test@1.2.3.Person";
+   [Newtonsoft.Json.JsonProperty("email")]
+   public string Email { get; set; }
+   [Newtonsoft.Json.JsonProperty("firstName")]
+   public string FirstName { get; set; }
+   [Newtonsoft.Json.JsonProperty("lastName")]
+   public string LastName { get; set; }
+}
+[Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+public enum Department {
       MARKETING,
       SALES,
       ENGINEERING,
       OPERATIONS,
-   }
-
-   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Employee")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Employee : Person {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Employee";
-      public Department? department { get; set; }
-      public Employee manager { get; set; }
-      public string employeeId { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Manager")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Manager : Employee {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "org.accordproject.concerto.test@1.2.3.Manager";
-      public float budget { get; set; }
-   }
+}
+[AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Employee")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Employee : Person {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "org.accordproject.concerto.test@1.2.3.Employee";
+   [Newtonsoft.Json.JsonProperty("department")]
+   public Department? Department { get; set; }
+   [Newtonsoft.Json.JsonProperty("manager")]
+   public Employee Manager { get; set; }
+   [Newtonsoft.Json.JsonProperty("employeeId")]
+   public string EmployeeId { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.accordproject.concerto.test", Version = "1.2.3", Name = "Manager")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Manager : Employee {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "org.accordproject.concerto.test@1.2.3.Manager";
+   [Newtonsoft.Json.JsonProperty("budget")]
+   public float Budget { get; set; }
 }

--- a/AccordProject.Concerto/ConcertoMetamodelTypes.cs
+++ b/AccordProject.Concerto/ConcertoMetamodelTypes.cs
@@ -12,302 +12,363 @@
  * limitations under the License.
  */
 
-namespace AccordProject.Concerto.Metamodel {
-   using AccordProject.Concerto;
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Position")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Position : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Position";
-      public int line { get; set; }
-      public int column { get; set; }
-      public int offset { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Range")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Range : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Range";
-      public Position start { get; set; }
-      public Position end { get; set; }
-      public string source { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TypeIdentifier")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class TypeIdentifier : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.TypeIdentifier";
-      public string name { get; set; }
-      [Newtonsoft.Json.JsonProperty("namespace")]
-		public string _namespace { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorLiteral")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class DecoratorLiteral : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorLiteral";
-      public Range location { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorString")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DecoratorString : DecoratorLiteral {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorString";
-      public string value { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorNumber")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DecoratorNumber : DecoratorLiteral {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorNumber";
-      public float value { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorBoolean")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DecoratorBoolean : DecoratorLiteral {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorBoolean";
-      public bool value { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorTypeReference")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DecoratorTypeReference : DecoratorLiteral {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DecoratorTypeReference";
-      public TypeIdentifier type { get; set; }
-      public bool isArray { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Decorator")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Decorator : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Decorator";
-      public string name { get; set; }
-      public DecoratorLiteral[] arguments { get; set; }
-      public Range location { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Identified")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Identified : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Identified";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IdentifiedBy")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class IdentifiedBy : Identified {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.IdentifiedBy";
-      public string name { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Declaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Declaration : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Declaration";
-      public string name { get; set; }
-      public Decorator[] decorators { get; set; }
-      public Range location { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class EnumDeclaration : Declaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumDeclaration";
-      public EnumProperty[] properties { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class EnumProperty : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.EnumProperty";
-      public string name { get; set; }
-      public Decorator[] decorators { get; set; }
-      public Range location { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ConceptDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ConceptDeclaration : Declaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ConceptDeclaration";
-      public bool isAbstract { get; set; }
-      public Identified identified { get; set; }
-      public TypeIdentifier superType { get; set; }
-      public Property[] properties { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "AssetDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class AssetDeclaration : ConceptDeclaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.AssetDeclaration";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ParticipantDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ParticipantDeclaration : ConceptDeclaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ParticipantDeclaration";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TransactionDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class TransactionDeclaration : ConceptDeclaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.TransactionDeclaration";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EventDeclaration")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class EventDeclaration : ConceptDeclaration {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.EventDeclaration";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Property")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Property : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Property";
-      public string name { get; set; }
-      public bool isArray { get; set; }
-      public bool isOptional { get; set; }
-      public Decorator[] decorators { get; set; }
-      public Range location { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "RelationshipProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class RelationshipProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.RelationshipProperty";
-      public TypeIdentifier type { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ObjectProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ObjectProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ObjectProperty";
-      public string defaultValue { get; set; }
-      public TypeIdentifier type { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "BooleanProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class BooleanProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.BooleanProperty";
-      public bool defaultValue { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DateTimeProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DateTimeProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DateTimeProperty";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class StringProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.StringProperty";
-      public string defaultValue { get; set; }
-      public StringRegexValidator validator { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringRegexValidator")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class StringRegexValidator : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.StringRegexValidator";
-      public string pattern { get; set; }
-      public string flags { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DoubleProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleProperty";
-      public float defaultValue { get; set; }
-      public DoubleDomainValidator validator { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleDomainValidator")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class DoubleDomainValidator : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.DoubleDomainValidator";
-      public float lower { get; set; }
-      public float upper { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class IntegerProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerProperty";
-      public int defaultValue { get; set; }
-      public IntegerDomainValidator validator { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerDomainValidator")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class IntegerDomainValidator : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.IntegerDomainValidator";
-      public int lower { get; set; }
-      public int upper { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongProperty")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class LongProperty : Property {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.LongProperty";
-      public long defaultValue { get; set; }
-      public LongDomainValidator validator { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongDomainValidator")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class LongDomainValidator : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.LongDomainValidator";
-      public long lower { get; set; }
-      public long upper { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Import")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Import : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Import";
-      [Newtonsoft.Json.JsonProperty("namespace")]
-		public string _namespace { get; set; }
-      public string uri { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportAll")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ImportAll : Import {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportAll";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportType")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ImportType : Import {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportType";
-      public string name { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportTypes")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class ImportTypes : Import {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.ImportTypes";
-      public string[] types { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Model")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Model : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Model";
-      [Newtonsoft.Json.JsonProperty("namespace")]
-		public string _namespace { get; set; }
-      public string sourceUri { get; set; }
-      public string concertoVersion { get; set; }
-      public Import[] imports { get; set; }
-      public Declaration[] declarations { get; set; }
-      public Decorator[] decorators { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Models")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public class Models : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto.metamodel@1.0.0.Models";
-      public Model[] models { get; set; }
-   }
+namespace AccordProject.Concerto.Metamodel;
+using AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Position")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Position : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Position";
+   [Newtonsoft.Json.JsonProperty("line")]
+   public int Line { get; set; }
+   [Newtonsoft.Json.JsonProperty("column")]
+   public int Column { get; set; }
+   [Newtonsoft.Json.JsonProperty("offset")]
+   public int Offset { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Range")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Range : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Range";
+   [Newtonsoft.Json.JsonProperty("start")]
+   public Position Start { get; set; }
+   [Newtonsoft.Json.JsonProperty("end")]
+   public Position End { get; set; }
+   [Newtonsoft.Json.JsonProperty("source")]
+   public string Source { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TypeIdentifier")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class TypeIdentifier : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.TypeIdentifier";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("namespace")]
+   public string Namespace { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorLiteral")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class DecoratorLiteral : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DecoratorLiteral";
+   [Newtonsoft.Json.JsonProperty("location")]
+   public Range Location { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorString")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DecoratorString : DecoratorLiteral {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DecoratorString";
+   [Newtonsoft.Json.JsonProperty("value")]
+   public string Value { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorNumber")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DecoratorNumber : DecoratorLiteral {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DecoratorNumber";
+   [Newtonsoft.Json.JsonProperty("value")]
+   public float Value { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorBoolean")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DecoratorBoolean : DecoratorLiteral {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DecoratorBoolean";
+   [Newtonsoft.Json.JsonProperty("value")]
+   public bool Value { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DecoratorTypeReference")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DecoratorTypeReference : DecoratorLiteral {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DecoratorTypeReference";
+   [Newtonsoft.Json.JsonProperty("type")]
+   public TypeIdentifier Type { get; set; }
+   [Newtonsoft.Json.JsonProperty("isArray")]
+   public bool IsArray { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Decorator")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Decorator : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Decorator";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("arguments")]
+   public DecoratorLiteral[] Arguments { get; set; }
+   [Newtonsoft.Json.JsonProperty("location")]
+   public Range Location { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Identified")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Identified : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Identified";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IdentifiedBy")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class IdentifiedBy : Identified {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.IdentifiedBy";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Declaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Declaration : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Declaration";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("decorators")]
+   public Decorator[] Decorators { get; set; }
+   [Newtonsoft.Json.JsonProperty("location")]
+   public Range Location { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class EnumDeclaration : Declaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.EnumDeclaration";
+   [Newtonsoft.Json.JsonProperty("properties")]
+   public EnumProperty[] Properties { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EnumProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class EnumProperty : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.EnumProperty";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("decorators")]
+   public Decorator[] Decorators { get; set; }
+   [Newtonsoft.Json.JsonProperty("location")]
+   public Range Location { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ConceptDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ConceptDeclaration : Declaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ConceptDeclaration";
+   [Newtonsoft.Json.JsonProperty("isAbstract")]
+   public bool IsAbstract { get; set; }
+   [Newtonsoft.Json.JsonProperty("identified")]
+   public Identified Identified { get; set; }
+   [Newtonsoft.Json.JsonProperty("superType")]
+   public TypeIdentifier SuperType { get; set; }
+   [Newtonsoft.Json.JsonProperty("properties")]
+   public Property[] Properties { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "AssetDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class AssetDeclaration : ConceptDeclaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.AssetDeclaration";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ParticipantDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ParticipantDeclaration : ConceptDeclaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ParticipantDeclaration";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "TransactionDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class TransactionDeclaration : ConceptDeclaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.TransactionDeclaration";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "EventDeclaration")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class EventDeclaration : ConceptDeclaration {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.EventDeclaration";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Property")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Property : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Property";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("isArray")]
+   public bool IsArray { get; set; }
+   [Newtonsoft.Json.JsonProperty("isOptional")]
+   public bool IsOptional { get; set; }
+   [Newtonsoft.Json.JsonProperty("decorators")]
+   public Decorator[] Decorators { get; set; }
+   [Newtonsoft.Json.JsonProperty("location")]
+   public Range Location { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "RelationshipProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class RelationshipProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.RelationshipProperty";
+   [Newtonsoft.Json.JsonProperty("type")]
+   public TypeIdentifier Type { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ObjectProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ObjectProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ObjectProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public string DefaultValue { get; set; }
+   [Newtonsoft.Json.JsonProperty("type")]
+   public TypeIdentifier Type { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "BooleanProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class BooleanProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.BooleanProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public bool DefaultValue { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DateTimeProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DateTimeProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DateTimeProperty";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class StringProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.StringProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public string DefaultValue { get; set; }
+   [Newtonsoft.Json.JsonProperty("validator")]
+   public StringRegexValidator Validator { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "StringRegexValidator")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class StringRegexValidator : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.StringRegexValidator";
+   [Newtonsoft.Json.JsonProperty("pattern")]
+   public string Pattern { get; set; }
+   [Newtonsoft.Json.JsonProperty("flags")]
+   public string Flags { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DoubleProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DoubleProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public float DefaultValue { get; set; }
+   [Newtonsoft.Json.JsonProperty("validator")]
+   public DoubleDomainValidator Validator { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "DoubleDomainValidator")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class DoubleDomainValidator : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.DoubleDomainValidator";
+   [Newtonsoft.Json.JsonProperty("lower")]
+   public float Lower { get; set; }
+   [Newtonsoft.Json.JsonProperty("upper")]
+   public float Upper { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class IntegerProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.IntegerProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public int DefaultValue { get; set; }
+   [Newtonsoft.Json.JsonProperty("validator")]
+   public IntegerDomainValidator Validator { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "IntegerDomainValidator")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class IntegerDomainValidator : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.IntegerDomainValidator";
+   [Newtonsoft.Json.JsonProperty("lower")]
+   public int Lower { get; set; }
+   [Newtonsoft.Json.JsonProperty("upper")]
+   public int Upper { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongProperty")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class LongProperty : Property {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.LongProperty";
+   [Newtonsoft.Json.JsonProperty("defaultValue")]
+   public long DefaultValue { get; set; }
+   [Newtonsoft.Json.JsonProperty("validator")]
+   public LongDomainValidator Validator { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "LongDomainValidator")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class LongDomainValidator : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.LongDomainValidator";
+   [Newtonsoft.Json.JsonProperty("lower")]
+   public long Lower { get; set; }
+   [Newtonsoft.Json.JsonProperty("upper")]
+   public long Upper { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Import")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Import : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Import";
+   [Newtonsoft.Json.JsonProperty("namespace")]
+   public string Namespace { get; set; }
+   [Newtonsoft.Json.JsonProperty("uri")]
+   public string Uri { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportAll")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ImportAll : Import {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ImportAll";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportType")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ImportType : Import {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ImportType";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "ImportTypes")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class ImportTypes : Import {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.ImportTypes";
+   [Newtonsoft.Json.JsonProperty("types")]
+   public string[] Types { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Model")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Model : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Model";
+   [Newtonsoft.Json.JsonProperty("namespace")]
+   public string Namespace { get; set; }
+   [Newtonsoft.Json.JsonProperty("sourceUri")]
+   public string SourceUri { get; set; }
+   [Newtonsoft.Json.JsonProperty("concertoVersion")]
+   public string ConcertoVersion { get; set; }
+   [Newtonsoft.Json.JsonProperty("imports")]
+   public Import[] Imports { get; set; }
+   [Newtonsoft.Json.JsonProperty("declarations")]
+   public Declaration[] Declarations { get; set; }
+   [Newtonsoft.Json.JsonProperty("decorators")]
+   public Decorator[] Decorators { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Models")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class Models : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.Models";
+   [Newtonsoft.Json.JsonProperty("models")]
+   public Model[] _Models { get; set; }
 }

--- a/AccordProject.Concerto/ConcertoTypes.cs
+++ b/AccordProject.Concerto/ConcertoTypes.cs
@@ -12,43 +12,42 @@
  * limitations under the License.
  */
 
-namespace AccordProject.Concerto {
-   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public virtual string _class { get; } = "concerto@1.0.0.Concept";
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Asset")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Asset : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto@1.0.0.Asset";
-      [Newtonsoft.Json.JsonProperty("$identifier")]
-		public string _identifier { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Participant")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Participant : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto@1.0.0.Participant";
-      [Newtonsoft.Json.JsonProperty("$identifier")]
-		public string _identifier { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Transaction")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Transaction : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto@1.0.0.Transaction";
-      [Newtonsoft.Json.JsonProperty("$timestamp")]
-		public System.DateTime _timestamp { get; set; }
-   }
-   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Event")]
-   [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
-   public abstract class Event : Concept {
-      [Newtonsoft.Json.JsonProperty("$class")]
-		public override string _class { get; } = "concerto@1.0.0.Event";
-      [Newtonsoft.Json.JsonProperty("$timestamp")]
-		public System.DateTime _timestamp { get; set; }
-   }
+namespace AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public virtual string _Class { get; } = "concerto@1.0.0.Concept";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Asset")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Asset : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto@1.0.0.Asset";
+   [Newtonsoft.Json.JsonProperty("$identifier")]
+   public string _Identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Participant")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Participant : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto@1.0.0.Participant";
+   [Newtonsoft.Json.JsonProperty("$identifier")]
+   public string _Identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Transaction")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Transaction : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto@1.0.0.Transaction";
+   [Newtonsoft.Json.JsonProperty("$timestamp")]
+   public System.DateTime _Timestamp { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Event")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public abstract class Event : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto@1.0.0.Event";
+   [Newtonsoft.Json.JsonProperty("$timestamp")]
+   public System.DateTime _Timestamp { get; set; }
 }


### PR DESCRIPTION
C# naming conventions (https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#naming-conventions) dictate that you should use PascalCase for namespace, class, enum and public members. 

This change regenerates all generated C# code using the changes delivered in https://github.com/accordproject/concerto/pull/517, meaning that we now conform to these conventions.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>