### PR TITLE
build: Build projects using .NET 8.0.

### DIFF
--- a/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
+++ b/AccordProject.Concerto.Tests/AccordProject.Concerto.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ExpectedObjects" Version="3.5.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/AccordProject.Concerto.Validate.Tests/AccordProject.Concerto.Validate.Tests.csproj
+++ b/AccordProject.Concerto.Validate.Tests/AccordProject.Concerto.Validate.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/AccordProject.Concerto.Validate/AccordProject.Concerto.Validate.csproj
+++ b/AccordProject.Concerto.Validate/AccordProject.Concerto.Validate.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
     <Target Name="WebPack" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild">
         <Exec Command="npm run build" WorkingDirectory="./concerto-validate" />

--- a/AccordProject.Concerto.Validate/concerto-validate/package-lock.json
+++ b/AccordProject.Concerto.Validate/concerto-validate/package-lock.json
@@ -1819,6 +1819,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/AccordProject.Concerto/AccordProject.Concerto.csproj
+++ b/AccordProject.Concerto/AccordProject.Concerto.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AccordProject.Concerto/ConcertoMetamodelTypes.cs
+++ b/AccordProject.Concerto/ConcertoMetamodelTypes.cs
@@ -431,6 +431,16 @@ public class LongDomainValidator : Concept {
    [Newtonsoft.Json.JsonProperty("upper")]
    public long? Upper { get; set; }
 }
+[AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "AliasedType")]
+[Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
+public class AliasedType : Concept {
+   [Newtonsoft.Json.JsonProperty("$class")]
+   public override string _Class { get; } = "concerto.metamodel@1.0.0.AliasedType";
+   [Newtonsoft.Json.JsonProperty("name")]
+   public string Name { get; set; }
+   [Newtonsoft.Json.JsonProperty("aliasedName")]
+   public string AliasedName { get; set; }
+}
 [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Import")]
 [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
 public abstract class Import : Concept {
@@ -462,6 +472,8 @@ public class ImportTypes : Import {
    public override string _Class { get; } = "concerto.metamodel@1.0.0.ImportTypes";
    [Newtonsoft.Json.JsonProperty("types")]
    public string[] Types { get; set; }
+   [Newtonsoft.Json.JsonProperty("aliasedTypes")]
+   public AliasedType?[] AliasedTypes { get; set; }
 }
 [AccordProject.Concerto.Type(Namespace = "concerto.metamodel", Version = "1.0.0", Name = "Model")]
 [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]

--- a/AccordProject.Concerto/ConcertoTypes.cs
+++ b/AccordProject.Concerto/ConcertoTypes.cs
@@ -13,6 +13,7 @@
  */
 
 namespace AccordProject.Concerto;
+using Concerto.Decorator;
 [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
 [Newtonsoft.Json.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterNewtonsoft))]
 public abstract class Concept {

--- a/AccordProject.Concerto/Decorator.cs
+++ b/AccordProject.Concerto/Decorator.cs
@@ -1,0 +1,1 @@
+﻿namespace AccordProject.Concerto.Decorator;

--- a/ConcertoJsonConverter.Tests/ConcertoJsonConverter.Tests.csproj
+++ b/ConcertoJsonConverter.Tests/ConcertoJsonConverter.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-      <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ExpectedObjects" Version="3.5.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ConcertoJsonConverter/ConcertoConverter.cs
+++ b/ConcertoJsonConverter/ConcertoConverter.cs
@@ -13,11 +13,11 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Reflection;
-using System.Linq;
-using System.Collections.Generic;
 using Concerto.Models.concerto;
 
 namespace Concerto.Serialization;
@@ -62,9 +62,12 @@ public class ConcertoConverter : JsonConverterFactory
 
         private object deserializeWithGenericType(Type type, String rawText, object options)
         {
-            MethodInfo method = typeof(JsonSerializer).GetMethods()
+            string[] expectedTypes = [typeof(string).FullName, typeof(JsonSerializerOptions).FullName];
+            var method = typeof(JsonSerializer).GetMethods()
                 .Where(x => x.Name == nameof(JsonSerializer.Deserialize))
-                .FirstOrDefault(x => x.IsGenericMethod);
+                .FirstOrDefault(
+                    x => x.IsGenericMethod && x.GetParameters().Select(p => p.ParameterType.FullName)
+                        .SequenceEqual(expectedTypes));
             return method.MakeGenericMethod(type).Invoke(null, new object[] { rawText, options});
         }
 

--- a/ConcertoJsonConverter/ConcertoJsonConverter.csproj
+++ b/ConcertoJsonConverter/ConcertoJsonConverter.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
-      <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+      <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
build: Build projects using .NET 8.0.

### Changes
- Update all projects' target framework in `.NET8.0` (from `standard2.0`)
- Update all projects' C# version to 12 (from 10)
- Updated NuGet packages
- Fixes for compilation:
1. `ConcertoConverter.deserializeWithGenericType` chose the wrong overloaded method. Added expected parameters to choose the correct method.
2. Added `Decorator.cs` to declare the existence of `AccordProject.Concerto.Decorator` namespace, because the code generation script added `using AccordProject.Concerto.Decorator` for some reason and the compilation failed.

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Vital features and changes captured in unit and/or integration tests  -- **no feature code changes ; existing tests should cover all changes**
- [X] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [X] Extend the documentation, if necessary -- **no changes to documentation are needed**
- [X] Merging to `main` from `ybavli-dsc:main`
