### PR TITLE
feat(util): add normalizeIdentifier utility method and tests

### DIFF
--- a/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
+++ b/AccordProject.Concerto.Tests/ConcertoUtilsTests.cs
@@ -147,4 +147,100 @@ public class ConcertoUtilsTests
         var project = new Project() {};
         Assert.Null(ConcertoUtils.GetIdentifier(project));
     }
+    
+    [Fact]
+    public void NormalizeIdentifier_NoOpValues()
+    {
+        var ids = new (object? id, string expected)[] {
+            ("a", "a"),
+            ("A", "A"),
+            ("ĦĔĽĻŎ", "ĦĔĽĻŎ"),
+            ("ǅ", "ǅ"),
+            ("ᾩ", "ᾩ"),
+            ("〱〱〱〱", "〱〱〱〱"),
+            ("जावास्क्रिप्ट", "जावास्क्रिप्ट"),
+            ("Ⅶ", "Ⅶ"),
+            ("$class", "$class"),
+            ("_class", "_class"),
+            ("\u03C9", "\u03C9"),
+            ("abc", "abc"),
+            ("a123", "a123"),
+            ("foo$bar", "foo$bar"),
+            ("foo_bar", "foo_bar"),
+            ("αβγδεζηθ", "αβγδεζηθ"),
+            ("foo\u03C9bar", "foo\u03C9bar"),
+            ("foo\u03c9bar", "foo\u03c9bar"),
+            ("foo‿bar", "foo‿bar"),
+            ("पः", "पः"),
+            ("CharlesⅢ", "CharlesⅢ"),
+            ("true", "true"),
+            ("false", "false"),
+            ("null", "null"),
+            ("while", "while"),
+            ("for", "for"),
+            ("nully", "nully"),
+            ("こんにちは世界", "こんにちは世界"),
+            ("foo\u200Cbar", "foo_bar"),
+            ("foo\u200Dbar", "foo_bar"),
+        };
+        foreach (var (id, expected) in ids)
+        {
+            Assert.Equal(expected, ConcertoUtils.NormalizeIdentifier(id, 30));
+        }
+    }
+
+    [Fact]
+    public void NormalizeIdentifier_BadIdentifiers()
+    {
+        var ids = new (object? id, string expected)[] {
+            ("123", "_123"),
+            ("1st", "_1st"),
+            ("foo bar", "foo_bar"),
+            ("foo\u0020bar", "foo_bar"),
+            ("\u200Dfoo", "_foo"),
+            ("foo-bar", "foo_bar"),
+            ("foo\u2010bar", "foo_bar"),
+            ("foo\u2212bar", "foo_bar"),
+            ("foo|bar", "foo_bar"),
+            ("foo@bar", "foo_bar"),
+            ("foo#bar", "foo_bar"),
+            ("foo/bar", "foo_bar"),
+            ("foo>bar", "foo_bar"),
+            ("foo.bar", "foo_bar"),
+            ("\x3D", "_3d"),
+            ("😄", "_1f604"),
+        };
+        foreach (var (id, expected) in ids)
+        {
+            Assert.Equal(expected, ConcertoUtils.NormalizeIdentifier(id, 30));
+        }
+    }
+
+    [Fact]
+    public void NormalizeIdentifier_ThrowsForEmptyString()
+    {
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(""));
+    }
+
+    [Fact]
+    public void NormalizeIdentifier_UnsupportedTypesThrow()
+    {
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(new { a = 1 }));
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(false));
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(true));
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(1));
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(1.112345678987654));
+        Assert.Throws<Exception>(() => ConcertoUtils.NormalizeIdentifier(3.1e2));
+    }
+
+    [Fact]
+    public void NormalizeIdentifier_Truncation()
+    {
+        Assert.Equal("a", ConcertoUtils.NormalizeIdentifier("a", 2));
+        Assert.Equal("aa", ConcertoUtils.NormalizeIdentifier("aaa", 2));
+        Assert.Equal("aaa", ConcertoUtils.NormalizeIdentifier("aaa", 0));
+        Assert.Equal("aaa", ConcertoUtils.NormalizeIdentifier("aaa", -1));
+        Assert.Equal("$", ConcertoUtils.NormalizeIdentifier("$a", 1));
+        Assert.Equal("_1", ConcertoUtils.NormalizeIdentifier("😄", 2));
+    }
 }

--- a/AccordProject.Concerto/ConcertoUtils.cs
+++ b/AccordProject.Concerto/ConcertoUtils.cs
@@ -15,6 +15,10 @@
 namespace AccordProject.Concerto;
 
 using System.Reflection;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions; 
+
 
 /// <summary>
 /// This class represents a Concerto type, for example org.example@1.2.3.Foo.
@@ -145,4 +149,63 @@ public class ConcertoUtils
         }
         return FindIdentifierProperty(baseType);
     }
+
+    private static readonly Regex ID_REGEX = new Regex(
+        @"^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant
+    );
+
+    public static string NormalizeIdentifier(object? identifier, int truncateLength = -1)
+    {
+        if (identifier is null) return "null";
+        if (identifier is not string) throw new Exception("Unsupported identifier type");
+        var result = (string)identifier;
+        if (result.Length == 0) throw new Exception("Unexpected error: empty identifier");
+
+        result = Regex.Replace(result, @"^\p{Nd}", "_$0");
+
+        result = Regex.Replace(result, @"[-‐−.@#:;><|/\\]", "_");
+        result = Regex.Replace(result, @"\s", "_");
+        result = Regex.Replace(result, @"[\u200C\u200D]", "_");
+
+        result = Regex.Replace(result, @"(?:[\uD800-\uDBFF][\uDC00-\uDFFF])", m => EscapeCodePointPair(m.Value));
+
+        result = Regex.Replace(
+            result,
+            @"(?!\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D|\\u[0-9A-Fa-f]{4})(.)",
+            m => EscapeCodePoints(m.Value),
+            RegexOptions.Singleline
+        );
+
+        result = Regex.Replace(result, @"[\uD800-\uDFFF]", m => EscapeCodePoints(m.Value));
+
+        if (truncateLength > 0 && result.Length >= truncateLength)
+        {
+            result = result[..truncateLength];
+        }
+
+        if (!ID_REGEX.IsMatch(result))
+        {
+            throw new Exception($"Unexpected error. Not able to escape identifier '{result}'.");
+        }
+
+        return result;
+    }
+
+    private static string EscapeCodePoints(string input)
+    {
+        var sb = new StringBuilder();
+        foreach (var rune in input.EnumerateRunes())
+        {
+            sb.Append('_');
+            sb.Append(rune.Value.ToString("x", CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    private static string EscapeCodePointPair(string pair)
+    {
+        var cp = char.ConvertToUtf32(pair, 0);
+        return "_" + cp.ToString("x", CultureInfo.InvariantCulture);
+    }   
 }


### PR DESCRIPTION
# Closes #34 
This PR adds the `normalizeIdentifier` method to the C# codebase to ensure consistent concept name normalization , as requested in issue #34.
The normalizeIdentifier method is used to normalize concept names according to the Concerto specification. While this functionality already exists in the JavaScript library, it was missing from the C# library.
### Changes
- <ONE>Added NormalizeIdentifier implementation in `ConcertoUtils.cs`
- <TWO>Added unit tests in `ConcertoUtilsTests.cs`

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
